### PR TITLE
Remove Rust version from workspace

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -218,7 +218,7 @@ dependencies = [
 
 [[package]]
 name = "dogstatsd"
-version = "0.0.0"
+version = "0.1.0"
 dependencies = [
  "datadog-protos",
  "ddsketch-agent",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,6 @@ members = [
 ]
 
 [workspace.package]
-rust-version = "1.85"
 edition = "2021"
 license = "Apache-2.0"
 homepage = "https://github.com/DataDog/serverless-components"

--- a/crates/dogstatsd/Cargo.toml
+++ b/crates/dogstatsd/Cargo.toml
@@ -1,6 +1,5 @@
 [package]
 name = "dogstatsd"
-rust-version.workspace = true
 edition.workspace = true
 license.workspace = true
 

--- a/crates/dogstatsd/Cargo.toml
+++ b/crates/dogstatsd/Cargo.toml
@@ -1,5 +1,6 @@
 [package]
 name = "dogstatsd"
+version = "0.1.0"
 edition.workspace = true
 license.workspace = true
 


### PR DESCRIPTION
### What does this PR do?

* Remove Rust version from workspace
* Add version 0.1.0 for dogstatsd crate

### Motivation

Failing tests in libdatadog due to forced Rust version:

```
error: rustc 1.78.0 is not supported by the following package:
  dogstatsd@0.0.0 requires rustc 1.85
Either upgrade rustc or select compatible dependency versions with
`cargo update <name>@<current-ver> --precise <compatible-ver>`
where `<compatible-ver>` is the latest version supporting rustc 1.78.0
```

Also we won't be maintaining the crate version for now but it looked odd to have version `0.0.0` in the Cargo lock file. So `0.1.0` will be the version for the time being.

### Additional Notes

Related PR in libdatadog: https://github.com/DataDog/libdatadog/pull/973

### Describe how to test/QA your changes

<!-- How was the change validated? Are there automated tests to prevent regressions? -->
