### PR TITLE
chore: update hashbrown to v0.15

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -224,7 +224,7 @@ dependencies = [
  "ddsketch-agent",
  "derive_more",
  "fnv",
- "hashbrown 0.14.5",
+ "hashbrown",
  "mockito",
  "proptest",
  "protobuf",
@@ -389,12 +389,6 @@ dependencies = [
  "tokio-util",
  "tracing",
 ]
-
-[[package]]
-name = "hashbrown"
-version = "0.14.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
 
 [[package]]
 name = "hashbrown"
@@ -667,7 +661,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3954d50fe15b02142bf25d3b8bdadb634ec3948f103d04ffe3031bc8fe9d7058"
 dependencies = [
  "equivalent",
- "hashbrown 0.15.2",
+ "hashbrown",
 ]
 
 [[package]]

--- a/crates/dogstatsd/Cargo.toml
+++ b/crates/dogstatsd/Cargo.toml
@@ -11,7 +11,7 @@ bench = false
 datadog-protos = { version = "0.1.0", default-features = false, git = "https://github.com/DataDog/saluki/", rev = "c89b58e5784b985819baf11f13f7d35876741222" }
 ddsketch-agent = { version = "0.1.0", default-features = false, git = "https://github.com/DataDog/saluki/", rev = "c89b58e5784b985819baf11f13f7d35876741222" }
 derive_more = { version = "1.0.0", features = ["display", "into"] }
-hashbrown = { version = "0.14.3", default-features = false, features = ["inline-more"] }
+hashbrown = { version = "0.15.0", default-features = false, features = ["inline-more"] }
 protobuf = { version = "3.5.0", default-features = false }
 ustr = { version = "1.0.0", default-features = false }
 fnv = { version = "1.0.7", default-features = false }


### PR DESCRIPTION
### What does this PR do?

Bumps hashbrown to 0.15.

### Motivation

https://github.com/DataDog/libdatadog/pull/1009

Drop hashbrown 0.14

```
hashbrown v0.14.5
└── dogstatsd v0.1.0 (/Users/levi.morrison/go/src/github.com/DataDog/serverless-components/crates/dogstatsd)

hashbrown v0.15.2
└── indexmap v2.8.0
    ├── h2 v0.4.8 (*)
    ├── petgraph v0.7.1
    │   └── prost-build v0.13.5 (*)
    └── protobuf-parse v3.7.2 (*)
```

### Additional Notes

<!-- Any other relevant context that would be helpful. -->

### Describe how to test/QA your changes

<!-- How was the change validated? Are there automated tests to prevent regressions? -->
