### PR TITLE
fix: use rev for libdatadog commit hash dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -734,7 +734,7 @@ version = "0.1.0"
 source = "git+https://github.com/DataDog/saluki/?rev=c89b58e5784b985819baf11f13f7d35876741222#c89b58e5784b985819baf11f13f7d35876741222"
 dependencies = [
  "bytes",
- "prost 0.13.5",
+ "prost",
  "protobuf",
  "protobuf-codegen",
  "tonic",
@@ -745,8 +745,8 @@ dependencies = [
 name = "datadog-serverless-compat"
 version = "0.1.0"
 dependencies = [
- "datadog-trace-protobuf 17.0.0 (git+https://github.com/DataDog/libdatadog/?rev=3dab0bed2e144ce78c10a2378d1aff8fb5974f7d)",
- "datadog-trace-utils 17.0.0 (git+https://github.com/DataDog/libdatadog/?rev=3dab0bed2e144ce78c10a2378d1aff8fb5974f7d)",
+ "datadog-trace-protobuf",
+ "datadog-trace-utils",
  "dogstatsd",
  "env_logger",
  "log",
@@ -761,19 +761,10 @@ dependencies = [
 [[package]]
 name = "datadog-trace-normalization"
 version = "17.0.0"
-source = "git+https://github.com/DataDog/libdatadog/?rev=3dab0bed2e144ce78c10a2378d1aff8fb5974f7d#3dab0bed2e144ce78c10a2378d1aff8fb5974f7d"
-dependencies = [
- "anyhow",
- "datadog-trace-protobuf 17.0.0 (git+https://github.com/DataDog/libdatadog/?rev=3dab0bed2e144ce78c10a2378d1aff8fb5974f7d)",
-]
-
-[[package]]
-name = "datadog-trace-normalization"
-version = "17.0.0"
 source = "git+https://github.com/DataDog/libdatadog/?rev=d6a2da32c6b92d6865a7e7987c8a1df2203fb1ae#d6a2da32c6b92d6865a7e7987c8a1df2203fb1ae"
 dependencies = [
  "anyhow",
- "datadog-trace-protobuf 17.0.0 (git+https://github.com/DataDog/libdatadog/?rev=d6a2da32c6b92d6865a7e7987c8a1df2203fb1ae)",
+ "datadog-trace-protobuf",
 ]
 
 [[package]]
@@ -782,9 +773,9 @@ version = "17.0.0"
 source = "git+https://github.com/DataDog/libdatadog/?rev=d6a2da32c6b92d6865a7e7987c8a1df2203fb1ae#d6a2da32c6b92d6865a7e7987c8a1df2203fb1ae"
 dependencies = [
  "anyhow",
- "datadog-trace-protobuf 17.0.0 (git+https://github.com/DataDog/libdatadog/?rev=d6a2da32c6b92d6865a7e7987c8a1df2203fb1ae)",
- "datadog-trace-utils 17.0.0 (git+https://github.com/DataDog/libdatadog/?rev=d6a2da32c6b92d6865a7e7987c8a1df2203fb1ae)",
- "ddcommon 17.0.0 (git+https://github.com/DataDog/libdatadog/?rev=d6a2da32c6b92d6865a7e7987c8a1df2203fb1ae)",
+ "datadog-trace-protobuf",
+ "datadog-trace-utils",
+ "ddcommon",
  "log",
  "percent-encoding",
  "regex",
@@ -796,46 +787,11 @@ dependencies = [
 [[package]]
 name = "datadog-trace-protobuf"
 version = "17.0.0"
-source = "git+https://github.com/DataDog/libdatadog/?rev=3dab0bed2e144ce78c10a2378d1aff8fb5974f7d#3dab0bed2e144ce78c10a2378d1aff8fb5974f7d"
-dependencies = [
- "prost 0.11.9",
- "serde",
- "serde_bytes",
-]
-
-[[package]]
-name = "datadog-trace-protobuf"
-version = "17.0.0"
 source = "git+https://github.com/DataDog/libdatadog/?rev=d6a2da32c6b92d6865a7e7987c8a1df2203fb1ae#d6a2da32c6b92d6865a7e7987c8a1df2203fb1ae"
 dependencies = [
- "prost 0.13.5",
+ "prost",
  "serde",
  "serde_bytes",
-]
-
-[[package]]
-name = "datadog-trace-utils"
-version = "17.0.0"
-source = "git+https://github.com/DataDog/libdatadog/?rev=3dab0bed2e144ce78c10a2378d1aff8fb5974f7d#3dab0bed2e144ce78c10a2378d1aff8fb5974f7d"
-dependencies = [
- "anyhow",
- "bytes",
- "datadog-trace-normalization 17.0.0 (git+https://github.com/DataDog/libdatadog/?rev=3dab0bed2e144ce78c10a2378d1aff8fb5974f7d)",
- "datadog-trace-protobuf 17.0.0 (git+https://github.com/DataDog/libdatadog/?rev=3dab0bed2e144ce78c10a2378d1aff8fb5974f7d)",
- "ddcommon 17.0.0 (git+https://github.com/DataDog/libdatadog/?rev=3dab0bed2e144ce78c10a2378d1aff8fb5974f7d)",
- "futures",
- "http-body-util",
- "hyper 1.6.0",
- "log",
- "prost 0.11.9",
- "rand 0.8.5",
- "rmp",
- "rmp-serde",
- "rmpv",
- "serde",
- "serde_json",
- "tinybytes 17.0.0 (git+https://github.com/DataDog/libdatadog/?rev=3dab0bed2e144ce78c10a2378d1aff8fb5974f7d)",
- "tokio",
 ]
 
 [[package]]
@@ -847,9 +803,9 @@ dependencies = [
  "bytes",
  "cargo-platform",
  "cargo_metadata",
- "datadog-trace-normalization 17.0.0 (git+https://github.com/DataDog/libdatadog/?rev=d6a2da32c6b92d6865a7e7987c8a1df2203fb1ae)",
- "datadog-trace-protobuf 17.0.0 (git+https://github.com/DataDog/libdatadog/?rev=d6a2da32c6b92d6865a7e7987c8a1df2203fb1ae)",
- "ddcommon 17.0.0 (git+https://github.com/DataDog/libdatadog/?rev=d6a2da32c6b92d6865a7e7987c8a1df2203fb1ae)",
+ "datadog-trace-normalization",
+ "datadog-trace-protobuf",
+ "ddcommon",
  "flate2",
  "futures",
  "http-body-util",
@@ -857,7 +813,7 @@ dependencies = [
  "hyper 1.6.0",
  "hyper-http-proxy",
  "log",
- "prost 0.13.5",
+ "prost",
  "rand 0.8.5",
  "rmp",
  "rmp-serde",
@@ -865,47 +821,10 @@ dependencies = [
  "serde",
  "serde_json",
  "testcontainers",
- "tinybytes 17.0.0 (git+https://github.com/DataDog/libdatadog/?rev=d6a2da32c6b92d6865a7e7987c8a1df2203fb1ae)",
+ "tinybytes",
  "tokio",
  "urlencoding",
  "zstd",
-]
-
-[[package]]
-name = "ddcommon"
-version = "17.0.0"
-source = "git+https://github.com/DataDog/libdatadog/?rev=3dab0bed2e144ce78c10a2378d1aff8fb5974f7d#3dab0bed2e144ce78c10a2378d1aff8fb5974f7d"
-dependencies = [
- "anyhow",
- "cc",
- "const_format",
- "futures",
- "futures-core",
- "futures-util",
- "hex",
- "http 1.3.1",
- "http-body 1.0.1",
- "http-body-util",
- "hyper 1.6.0",
- "hyper-rustls",
- "hyper-util",
- "libc",
- "log",
- "memfd",
- "nix",
- "pin-project",
- "rand 0.8.5",
- "regex",
- "rmp",
- "rmp-serde",
- "rustls",
- "rustls-native-certs 0.8.1",
- "serde",
- "static_assertions",
- "tokio",
- "tokio-rustls",
- "tower-service",
- "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -2027,15 +1946,6 @@ dependencies = [
 
 [[package]]
 name = "itertools"
-version = "0.10.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
-dependencies = [
- "either",
-]
-
-[[package]]
-name = "itertools"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b1c173a5686ce8bfa551b3563d0c2170bf24ca44da99c7ca4bfdab5418c3fe57"
@@ -2653,22 +2563,12 @@ dependencies = [
 
 [[package]]
 name = "prost"
-version = "0.11.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b82eaa1d779e9a4bc1c3217db8ffbeabaae1dca241bf70183242128d48681cd"
-dependencies = [
- "bytes",
- "prost-derive 0.11.9",
-]
-
-[[package]]
-name = "prost"
 version = "0.13.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2796faa41db3ec313a31f7624d9286acf277b52de526150b7e69f3debf891ee5"
 dependencies = [
  "bytes",
- "prost-derive 0.13.5",
+ "prost-derive",
 ]
 
 [[package]]
@@ -2684,24 +2584,11 @@ dependencies = [
  "once_cell",
  "petgraph 0.7.1",
  "prettyplease",
- "prost 0.13.5",
+ "prost",
  "prost-types",
  "regex",
  "syn 2.0.100",
  "tempfile",
-]
-
-[[package]]
-name = "prost-derive"
-version = "0.11.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5d2d8d10f3c6ded6da8b05b5fb3b8a5082514344d56c9f871412d29b4e075b4"
-dependencies = [
- "anyhow",
- "itertools 0.10.5",
- "proc-macro2",
- "quote",
- "syn 1.0.109",
 ]
 
 [[package]]
@@ -2723,7 +2610,7 @@ version = "0.13.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52c2c1bf36ddb1a1c396b3601a3cec27c2462e45f07c386894ec3ccf5332bd16"
 dependencies = [
- "prost 0.13.5",
+ "prost",
 ]
 
 [[package]]
@@ -3752,14 +3639,6 @@ dependencies = [
 [[package]]
 name = "tinybytes"
 version = "17.0.0"
-source = "git+https://github.com/DataDog/libdatadog/?rev=3dab0bed2e144ce78c10a2378d1aff8fb5974f7d#3dab0bed2e144ce78c10a2378d1aff8fb5974f7d"
-dependencies = [
- "serde",
-]
-
-[[package]]
-name = "tinybytes"
-version = "17.0.0"
 source = "git+https://github.com/DataDog/libdatadog/?rev=d6a2da32c6b92d6865a7e7987c8a1df2203fb1ae#d6a2da32c6b92d6865a7e7987c8a1df2203fb1ae"
 dependencies = [
  "serde",
@@ -3866,7 +3745,7 @@ dependencies = [
  "http-body-util",
  "percent-encoding",
  "pin-project",
- "prost 0.13.5",
+ "prost",
  "tokio-stream",
  "tower-layer",
  "tower-service",
@@ -3920,11 +3799,11 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "async-trait",
- "datadog-trace-normalization 17.0.0 (git+https://github.com/DataDog/libdatadog/?rev=d6a2da32c6b92d6865a7e7987c8a1df2203fb1ae)",
+ "datadog-trace-normalization",
  "datadog-trace-obfuscation",
- "datadog-trace-protobuf 17.0.0 (git+https://github.com/DataDog/libdatadog/?rev=d6a2da32c6b92d6865a7e7987c8a1df2203fb1ae)",
- "datadog-trace-utils 17.0.0 (git+https://github.com/DataDog/libdatadog/?rev=d6a2da32c6b92d6865a7e7987c8a1df2203fb1ae)",
- "ddcommon 17.0.0 (git+https://github.com/DataDog/libdatadog/?rev=d6a2da32c6b92d6865a7e7987c8a1df2203fb1ae)",
+ "datadog-trace-protobuf",
+ "datadog-trace-utils",
+ "ddcommon",
  "duplicate",
  "http-body-util",
  "hyper 1.6.0",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -770,21 +770,21 @@ dependencies = [
 [[package]]
 name = "datadog-trace-normalization"
 version = "17.0.0"
-source = "git+https://github.com/DataDog/libdatadog/#d6a2da32c6b92d6865a7e7987c8a1df2203fb1ae"
+source = "git+https://github.com/DataDog/libdatadog/?rev=d6a2da32c6b92d6865a7e7987c8a1df2203fb1ae#d6a2da32c6b92d6865a7e7987c8a1df2203fb1ae"
 dependencies = [
  "anyhow",
- "datadog-trace-protobuf 17.0.0 (git+https://github.com/DataDog/libdatadog/)",
+ "datadog-trace-protobuf 17.0.0 (git+https://github.com/DataDog/libdatadog/?rev=d6a2da32c6b92d6865a7e7987c8a1df2203fb1ae)",
 ]
 
 [[package]]
 name = "datadog-trace-obfuscation"
 version = "17.0.0"
-source = "git+https://github.com/DataDog/libdatadog/#d6a2da32c6b92d6865a7e7987c8a1df2203fb1ae"
+source = "git+https://github.com/DataDog/libdatadog/?rev=d6a2da32c6b92d6865a7e7987c8a1df2203fb1ae#d6a2da32c6b92d6865a7e7987c8a1df2203fb1ae"
 dependencies = [
  "anyhow",
- "datadog-trace-protobuf 17.0.0 (git+https://github.com/DataDog/libdatadog/)",
- "datadog-trace-utils 17.0.0 (git+https://github.com/DataDog/libdatadog/)",
- "ddcommon 17.0.0 (git+https://github.com/DataDog/libdatadog/)",
+ "datadog-trace-protobuf 17.0.0 (git+https://github.com/DataDog/libdatadog/?rev=d6a2da32c6b92d6865a7e7987c8a1df2203fb1ae)",
+ "datadog-trace-utils 17.0.0 (git+https://github.com/DataDog/libdatadog/?rev=d6a2da32c6b92d6865a7e7987c8a1df2203fb1ae)",
+ "ddcommon 17.0.0 (git+https://github.com/DataDog/libdatadog/?rev=d6a2da32c6b92d6865a7e7987c8a1df2203fb1ae)",
  "log",
  "percent-encoding",
  "regex",
@@ -806,7 +806,7 @@ dependencies = [
 [[package]]
 name = "datadog-trace-protobuf"
 version = "17.0.0"
-source = "git+https://github.com/DataDog/libdatadog/#d6a2da32c6b92d6865a7e7987c8a1df2203fb1ae"
+source = "git+https://github.com/DataDog/libdatadog/?rev=d6a2da32c6b92d6865a7e7987c8a1df2203fb1ae#d6a2da32c6b92d6865a7e7987c8a1df2203fb1ae"
 dependencies = [
  "prost 0.13.5",
  "serde",
@@ -841,15 +841,15 @@ dependencies = [
 [[package]]
 name = "datadog-trace-utils"
 version = "17.0.0"
-source = "git+https://github.com/DataDog/libdatadog/#d6a2da32c6b92d6865a7e7987c8a1df2203fb1ae"
+source = "git+https://github.com/DataDog/libdatadog/?rev=d6a2da32c6b92d6865a7e7987c8a1df2203fb1ae#d6a2da32c6b92d6865a7e7987c8a1df2203fb1ae"
 dependencies = [
  "anyhow",
  "bytes",
  "cargo-platform",
  "cargo_metadata",
- "datadog-trace-normalization 17.0.0 (git+https://github.com/DataDog/libdatadog/)",
- "datadog-trace-protobuf 17.0.0 (git+https://github.com/DataDog/libdatadog/)",
- "ddcommon 17.0.0 (git+https://github.com/DataDog/libdatadog/)",
+ "datadog-trace-normalization 17.0.0 (git+https://github.com/DataDog/libdatadog/?rev=d6a2da32c6b92d6865a7e7987c8a1df2203fb1ae)",
+ "datadog-trace-protobuf 17.0.0 (git+https://github.com/DataDog/libdatadog/?rev=d6a2da32c6b92d6865a7e7987c8a1df2203fb1ae)",
+ "ddcommon 17.0.0 (git+https://github.com/DataDog/libdatadog/?rev=d6a2da32c6b92d6865a7e7987c8a1df2203fb1ae)",
  "flate2",
  "futures",
  "http-body-util",
@@ -865,7 +865,7 @@ dependencies = [
  "serde",
  "serde_json",
  "testcontainers",
- "tinybytes 17.0.0 (git+https://github.com/DataDog/libdatadog/)",
+ "tinybytes 17.0.0 (git+https://github.com/DataDog/libdatadog/?rev=d6a2da32c6b92d6865a7e7987c8a1df2203fb1ae)",
  "tokio",
  "urlencoding",
  "zstd",
@@ -911,7 +911,7 @@ dependencies = [
 [[package]]
 name = "ddcommon"
 version = "17.0.0"
-source = "git+https://github.com/DataDog/libdatadog/#d6a2da32c6b92d6865a7e7987c8a1df2203fb1ae"
+source = "git+https://github.com/DataDog/libdatadog/?rev=d6a2da32c6b92d6865a7e7987c8a1df2203fb1ae#d6a2da32c6b92d6865a7e7987c8a1df2203fb1ae"
 dependencies = [
  "anyhow",
  "cc",
@@ -3760,7 +3760,7 @@ dependencies = [
 [[package]]
 name = "tinybytes"
 version = "17.0.0"
-source = "git+https://github.com/DataDog/libdatadog/#d6a2da32c6b92d6865a7e7987c8a1df2203fb1ae"
+source = "git+https://github.com/DataDog/libdatadog/?rev=d6a2da32c6b92d6865a7e7987c8a1df2203fb1ae#d6a2da32c6b92d6865a7e7987c8a1df2203fb1ae"
 dependencies = [
  "serde",
 ]
@@ -3920,11 +3920,11 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "async-trait",
- "datadog-trace-normalization 17.0.0 (git+https://github.com/DataDog/libdatadog/)",
+ "datadog-trace-normalization 17.0.0 (git+https://github.com/DataDog/libdatadog/?rev=d6a2da32c6b92d6865a7e7987c8a1df2203fb1ae)",
  "datadog-trace-obfuscation",
- "datadog-trace-protobuf 17.0.0 (git+https://github.com/DataDog/libdatadog/)",
- "datadog-trace-utils 17.0.0 (git+https://github.com/DataDog/libdatadog/)",
- "ddcommon 17.0.0 (git+https://github.com/DataDog/libdatadog/)",
+ "datadog-trace-protobuf 17.0.0 (git+https://github.com/DataDog/libdatadog/?rev=d6a2da32c6b92d6865a7e7987c8a1df2203fb1ae)",
+ "datadog-trace-utils 17.0.0 (git+https://github.com/DataDog/libdatadog/?rev=d6a2da32c6b92d6865a7e7987c8a1df2203fb1ae)",
+ "ddcommon 17.0.0 (git+https://github.com/DataDog/libdatadog/?rev=d6a2da32c6b92d6865a7e7987c8a1df2203fb1ae)",
  "duplicate",
  "http-body-util",
  "hyper 1.6.0",

--- a/crates/serverless-compat/Cargo.toml
+++ b/crates/serverless-compat/Cargo.toml
@@ -9,8 +9,8 @@ description = "Binary to run trace-agent and dogstatsd servers in Serverless env
 log = "0.4"
 env_logger = "0.10.0"
 trace-agent = { path = "../trace-agent" }
-datadog-trace-protobuf = { git = "https://github.com/DataDog/libdatadog/", rev = "3dab0bed2e144ce78c10a2378d1aff8fb5974f7d" }
-datadog-trace-utils = { git = "https://github.com/DataDog/libdatadog/", rev = "3dab0bed2e144ce78c10a2378d1aff8fb5974f7d" }
+datadog-trace-protobuf = { git = "https://github.com/DataDog/libdatadog/", rev = "d6a2da32c6b92d6865a7e7987c8a1df2203fb1ae" }
+datadog-trace-utils = { git = "https://github.com/DataDog/libdatadog/", rev = "d6a2da32c6b92d6865a7e7987c8a1df2203fb1ae" }
 dogstatsd = { path = "../dogstatsd", default-features = false }
 tokio = { version = "1", features = ["macros", "rt-multi-thread"]}
 tokio-util = { version = "0.7", default-features = false }

--- a/crates/trace-agent/Cargo.toml
+++ b/crates/trace-agent/Cargo.toml
@@ -18,15 +18,15 @@ async-trait = "0.1.64"
 tracing = { version = "0.1", default-features = false }
 serde = { version = "1.0.145", features = ["derive"] }
 serde_json = "1.0"
-ddcommon = { git = "https://github.com/DataDog/libdatadog/", ref = "d6a2da32c6b92d6865a7e7987c8a1df2203fb1ae" }
-datadog-trace-protobuf = { git = "https://github.com/DataDog/libdatadog/", ref = "d6a2da32c6b92d6865a7e7987c8a1df2203fb1ae" }
-datadog-trace-utils = { git = "https://github.com/DataDog/libdatadog/", ref = "d6a2da32c6b92d6865a7e7987c8a1df2203fb1ae", features = ["mini_agent"] }
-datadog-trace-normalization = { git = "https://github.com/DataDog/libdatadog/", ref = "d6a2da32c6b92d6865a7e7987c8a1df2203fb1ae" }
-datadog-trace-obfuscation = { git = "https://github.com/DataDog/libdatadog/", ref = "d6a2da32c6b92d6865a7e7987c8a1df2203fb1ae" }
+ddcommon = { git = "https://github.com/DataDog/libdatadog/", rev = "d6a2da32c6b92d6865a7e7987c8a1df2203fb1ae" }
+datadog-trace-protobuf = { git = "https://github.com/DataDog/libdatadog/", rev = "d6a2da32c6b92d6865a7e7987c8a1df2203fb1ae" }
+datadog-trace-utils = { git = "https://github.com/DataDog/libdatadog/", rev = "d6a2da32c6b92d6865a7e7987c8a1df2203fb1ae", features = ["mini_agent"] }
+datadog-trace-normalization = { git = "https://github.com/DataDog/libdatadog/", rev = "d6a2da32c6b92d6865a7e7987c8a1df2203fb1ae" }
+datadog-trace-obfuscation = { git = "https://github.com/DataDog/libdatadog/", rev = "d6a2da32c6b92d6865a7e7987c8a1df2203fb1ae" }
 
 [dev-dependencies]
 rmp-serde = "1.1.1"
 serial_test = "2.0.0"
 duplicate = "0.4.1"
 tempfile = "3.3.0"
-datadog-trace-utils = { git = "https://github.com/DataDog/libdatadog/", ref = "d6a2da32c6b92d6865a7e7987c8a1df2203fb1ae", features=["test-utils"] }
+datadog-trace-utils = { git = "https://github.com/DataDog/libdatadog/", rev = "d6a2da32c6b92d6865a7e7987c8a1df2203fb1ae", features=["test-utils"] }


### PR DESCRIPTION
### What does this PR do?

- use rev for libdatadog commit hash dependencies
- update all crates to use the same commit hash from libdatadog

### Motivation

Duplicate dependencies in `Cargo.lock` and compilation errors from Bottlecap.

### Additional Notes

<!-- Any other relevant context that would be helpful. -->

### Describe how to test/QA your changes

<!-- How was the change validated? Are there automated tests to prevent regressions? -->
