### PR TITLE
fix: enable default datadog-fips features from dogstatsd

### DIFF
--- a/.github/workflows/cargo.yml
+++ b/.github/workflows/cargo.yml
@@ -74,6 +74,26 @@ jobs:
       - shell: bash
         run: cargo build --all
 
+  build-datadog-serverless-compat:
+    name: Build Datadog Serverless Compat
+    if: ${{ inputs.runner != 'ubuntu-24.04-arm' }}
+    needs: setup
+    runs-on: ${{ inputs.runner }}
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - name: Install Protoc Binary
+        shell: bash
+        run: chmod +x ./scripts/install-protoc.sh && ./scripts/install-protoc.sh $HOME
+      - if: ${{ inputs.runner == 'ubuntu-24.04' }}
+        shell: bash
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y musl-tools
+          cargo build --release -p datadog-serverless-compat --target x86_64-unknown-linux-musl
+      - if: ${{ inputs.runner == 'windows-2022' }}
+        shell: bash
+        run: cargo build --release -p datadog-serverless-compat
+
   test:
     name: Test
     needs: setup

--- a/.github/workflows/cargo.yml
+++ b/.github/workflows/cargo.yml
@@ -88,7 +88,7 @@ jobs:
         shell: bash
         run: |
           sudo apt-get update
-          sudo apt-get install -y musl-tools
+          rustup target add x86_64-unknown-linux-musl && sudo apt-get install -y musl-tools
           cargo build --release -p datadog-serverless-compat --target x86_64-unknown-linux-musl
       - if: ${{ inputs.runner == 'windows-2022' }}
         shell: bash

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -9,6 +9,7 @@ on:
 jobs:
   cargo:
     strategy:
+      fail-fast: false
       matrix:
         runner: [ubuntu-24.04, ubuntu-24.04-arm, windows-2022]
     uses: ./.github/workflows/cargo.yml

--- a/crates/datadog-serverless-compat/Cargo.toml
+++ b/crates/datadog-serverless-compat/Cargo.toml
@@ -11,7 +11,7 @@ env_logger = "0.10.0"
 datadog-trace-agent = { path = "../datadog-trace-agent" }
 datadog-trace-protobuf = { git = "https://github.com/DataDog/libdatadog/", rev = "d6a2da32c6b92d6865a7e7987c8a1df2203fb1ae" }
 datadog-trace-utils = { git = "https://github.com/DataDog/libdatadog/", rev = "d6a2da32c6b92d6865a7e7987c8a1df2203fb1ae" }
-dogstatsd = { path = "../dogstatsd", default-features = false }
+dogstatsd = { path = "../dogstatsd", default-features = true }
 tokio = { version = "1", features = ["macros", "rt-multi-thread"]}
 tokio-util = { version = "0.7", default-features = false }
 tracing = { version = "0.1", default-features = false }

--- a/crates/dogstatsd/Cargo.toml
+++ b/crates/dogstatsd/Cargo.toml
@@ -24,7 +24,7 @@ tokio-util = { version = "0.7.11", default-features = false }
 tracing = { version = "0.1.40", default-features = false }
 regex = { version = "1.10.6", default-features = false }
 zstd = { version = "0.13.3", default-features = false }
-datadog-fips = { path = "../datadog-fips", default-features = true }
+datadog-fips = { path = "../datadog-fips", default-features = false }
 
 [dev-dependencies]
 mockito = { version = "1.5.0", default-features = false }

--- a/crates/dogstatsd/Cargo.toml
+++ b/crates/dogstatsd/Cargo.toml
@@ -24,7 +24,7 @@ tokio-util = { version = "0.7.11", default-features = false }
 tracing = { version = "0.1.40", default-features = false }
 regex = { version = "1.10.6", default-features = false }
 zstd = { version = "0.13.3", default-features = false }
-datadog-fips = { path = "../datadog-fips", default-features = false }
+datadog-fips = { path = "../datadog-fips", default-features = true }
 
 [dev-dependencies]
 mockito = { version = "1.5.0", default-features = false }


### PR DESCRIPTION
### What does this PR do?

Enable default `datadog-fips` features from `dogstatsd`.

### Motivation

Error when building `datadog-serverless-compat` without the `reqwest/rustls-tls` feature:
https://github.com/DataDog/serverless-components/blob/619d378db242e8bb797980b09af714fbecf12755/crates/datadog-fips/Cargo.toml#L16

```
serverless-components % sudo RUSTFLAGS="-C linker=x86_64-linux-musl-gcc" cargo build --release -p datadog-serverless-compat --target x86_64-unknown-linux-musl
   Compiling datadog-fips v0.1.0 (/Users/duncan.harvey/go/src/github.com/DataDog/serverless-components/crates/datadog-fips)
error[E0599]: no method named `use_rustls_tls` found for struct `ClientBuilder` in the current scope
  --> crates/datadog-fips/src/reqwest_adapter.rs:14:35
   |
14 |     Ok(reqwest::Client::builder().use_rustls_tls())
   |                                   ^^^^^^^^^^^^^^ method not found in `ClientBuilder`

For more information about this error, try `rustc --explain E0599`.
error: could not compile `datadog-fips` (lib) due to 1 previous error
```

### Additional Notes

* Skip `ubuntu-24.04-arm` build for Datadog Serverless Compat since this architecture is not supported by Azure Functions or Google Cloud Run Functions at this time
* Set `fail-fast` to `false` for Github Actions to false to allow for all jobs to run independently of other failures.

### Describe how to test/QA your changes

Added build step for `datadog-serverless-compat` to CI to catch build errors in the future.
