### PR TITLE
chore: add release workflow for datadog-serverless-compat

### DIFF
--- a/.github/workflows/build-datadog-serverless-compat.yml
+++ b/.github/workflows/build-datadog-serverless-compat.yml
@@ -1,0 +1,54 @@
+name: Build Datadog Serverless Compat
+
+on:
+  workflow_call:
+    inputs:
+      runner:
+        required: true
+        type: string
+
+jobs:
+  setup:
+    name: Setup
+    runs-on: ${{ inputs.runner }}
+    env:
+      CARGO_INCREMENTAL: "0"
+      SCCACHE_GHA_ENABLED: "true"
+      RUSTC_WRAPPER: "sccache"
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - uses: actions-rust-lang/setup-rust-toolchain@9399c7bb15d4c7d47b27263d024f0a4978346ba4 # v1.11.0
+        with:
+          cache: false
+      - uses: mozilla-actions/sccache-action@65101d47ea8028ed0c98a1cdea8dd9182e9b5133 #v0.0.8
+  build-datadog-serverless-compat:
+    name: Build Datadog Serverless Compat
+    if: ${{ inputs.runner != 'ubuntu-24.04-arm' }}
+    needs: setup
+    runs-on: ${{ inputs.runner }}
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - name: Install Protoc Binary
+        shell: bash
+        run: chmod +x ./scripts/install-protoc.sh && ./scripts/install-protoc.sh $HOME
+      - if: ${{ inputs.runner == 'ubuntu-24.04' }}
+        shell: bash
+        run: |
+          sudo apt-get update
+          rustup target add x86_64-unknown-linux-musl && sudo apt-get install -y musl-tools
+          cargo build --release -p datadog-serverless-compat --target x86_64-unknown-linux-musl
+      - if: ${{ inputs.runner == 'ubuntu-24.04' }}
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # 4.6.2
+        with:
+          name: linux-amd64
+          path: target/x86_64-unknown-linux-musl/release/datadog-serverless-compat
+          retention-days: 3
+      - if: ${{ inputs.runner == 'windows-2022' }}
+        shell: bash
+        run: cargo build --release -p datadog-serverless-compat
+      - if: ${{ inputs.runner == 'windows-2022' }}
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # 4.6.2
+        with:
+          name: windows-amd64
+          path: target/release/datadog-serverless-compat.exe
+          retention-days: 3

--- a/.github/workflows/cargo.yml
+++ b/.github/workflows/cargo.yml
@@ -76,23 +76,9 @@ jobs:
 
   build-datadog-serverless-compat:
     name: Build Datadog Serverless Compat
-    if: ${{ inputs.runner != 'ubuntu-24.04-arm' }}
-    needs: setup
-    runs-on: ${{ inputs.runner }}
-    steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-      - name: Install Protoc Binary
-        shell: bash
-        run: chmod +x ./scripts/install-protoc.sh && ./scripts/install-protoc.sh $HOME
-      - if: ${{ inputs.runner == 'ubuntu-24.04' }}
-        shell: bash
-        run: |
-          sudo apt-get update
-          rustup target add x86_64-unknown-linux-musl && sudo apt-get install -y musl-tools
-          cargo build --release -p datadog-serverless-compat --target x86_64-unknown-linux-musl
-      - if: ${{ inputs.runner == 'windows-2022' }}
-        shell: bash
-        run: cargo build --release -p datadog-serverless-compat
+    uses: ./.github/workflows/build-datadog-serverless-compat.yml
+    with:
+      runner: ${{ inputs.runner }}
 
   test:
     name: Test

--- a/.github/workflows/release-datadog-serverless-compat.yml
+++ b/.github/workflows/release-datadog-serverless-compat.yml
@@ -1,0 +1,36 @@
+name: Release Datadog Serverless Compat
+
+on: workflow_dispatch
+
+permissions: {}
+
+jobs:
+  build:
+    strategy:
+      fail-fast: false
+      matrix:
+        runner: [ubuntu-24.04, windows-2022]
+    uses: ./.github/workflows/build-datadog-serverless-compat.yml
+    with:
+      runner: ${{matrix.runner}}
+  release:
+    runs-on: ubuntu-24.04
+    needs: build
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # 4.3.0
+        with:
+          path: target/bin
+      - run: |
+          chmod +x target/bin/linux-amd64/datadog-serverless-compat
+          chmod +x target/bin/windows-amd64/datadog-serverless-compat.exe
+          upx target/bin/linux-amd64/datadog-serverless-compat --lzma
+          upx target/bin/windows-amd64/datadog-serverless-compat.exe --lzma
+      - run: zip -r datadog-serverless-compat.zip ./*
+        working-directory: target
+      - uses: softprops/action-gh-release@da05d552573ad5aba039eaac05058a918a7bf631 # v2.2.2
+        with:
+          draft: true
+          generate_release_notes: true
+          files: target/datadog-serverless-compat.zip


### PR DESCRIPTION
### What does this PR do?

Adds Github Workflow to release `datadog-serverless-compat` binaries for linux and windows.

### Motivation

Allow Serverless Compatibility Layer packages (Python, Node, Java, .NET) to be built with the latest version of the `datadog-serverless-compat` binaries.

### Additional Notes

Mimics workflow from libdatadog: https://github.com/DataDog/libdatadog/blob/10962937b6ff2e3e653f12f15beeaf27ea3d5e7f/.github/workflows/publish-serverless-agent.yml

### Describe how to test/QA your changes

Created test release and built [Serverless Compatibility Layer package for Python](https://github.com/DataDog/datadog-serverless-compat-py) from test release in serverless-components.
