### PR TITLE
Fix parsing metrics with decimal timestamp

### DIFF
--- a/crates/dogstatsd/src/metric.rs
+++ b/crates/dogstatsd/src/metric.rs
@@ -268,7 +268,10 @@ pub fn parse(input: &str) -> Result<Metric, ParseError> {
             .unwrap_or_default();
         // let Metric::new() handle bucketing the timestamp
         let parsed_timestamp: i64 = match caps.name("timestamp") {
-            Some(ts) => timestamp_to_bucket(ts.as_str().parse().unwrap_or(now)),
+            Some(ts) => {
+                let sec = ts.as_str().parse::<f64>().unwrap_or(now as f64).round() as i64;
+                timestamp_to_bucket(sec)
+            }
             None => timestamp_to_bucket(now),
         };
         let metric_value = match t {
@@ -621,6 +624,13 @@ mod tests {
         // Important to test that we round down to the nearest 10 seconds
         // for our buckets
         let input = "page.views:15|c|#env:dev|T1656581409";
+        let metric = parse(input).unwrap();
+        assert_eq!(metric.timestamp, 1656581400);
+    }
+
+    #[test]
+    fn parse_decimal_metric_timestamp() {
+        let input = "page.views:15|c|#env:dev|T1656581409.123";
         let metric = parse(input).unwrap();
         assert_eq!(metric.timestamp, 1656581400);
     }


### PR DESCRIPTION
### What does this PR do?

When receiving metrics over dogstatsd, we receive metrics in the format: `metric.name:15|c|#env:dev|T1656581409`, where `T1656581409` is the timestamp.

We parse the timestamp as `i64`, which means that if the timestamp is a float such as `T1656581409.123`, the parse will fail, and we fallback to `now`.

### Motivation

Just for flexibility. Even though metrics are rounded to the nearest 10 second bucket, we should still support decimal input.

E.g. v108 of datadog-lambda-python sends timestamped metrics with decimals. Therefore, we currently fallback to `now` since the parse as u64 fails.

### Additional Notes

<!-- Any other relevant context that would be helpful. -->

### Describe how to test/QA your changes

I tested manually with local builds of Node+Extension, where Node was sending timestamps with a decimal:
<img width="400" alt="Screenshot 2025-05-08 at 10 56 49 AM" src="https://github.com/user-attachments/assets/ca3c8818-bfe7-4f71-8e65-53d182785bdb" />
<img width="800" alt="Screenshot 2025-05-08 at 11 07 35 AM" src="https://github.com/user-attachments/assets/47f6a1aa-1c19-4c63-8ff0-bc7b25a0d23f" />
- Used datadog-lambda-js branch from https://github.com/DataDog/datadog-lambda-js/pull/648
- Built my own lambda extension layer: `arn:aws:lambda:us-east-1:<sandbox account>:layer:nhulston-datadog-extension:336`

And timestamped metrics now work as expected:
<img width="900" alt="Screenshot 2025-05-08 at 10 59 58 AM" src="https://github.com/user-attachments/assets/d290bff3-1818-4086-ac9a-bfd64cc2df35" />

Also added a basic unit test
