### PR TITLE
Optionally redrive failed requests

### DIFF
--- a/crates/datadog-trace-agent/src/trace_flusher.rs
+++ b/crates/datadog-trace-agent/src/trace_flusher.rs
@@ -97,8 +97,10 @@ impl TraceFlusher for ServerlessTraceFlusher {
         }
         debug!("Flushing {} traces", traces.len());
 
-        // Process and send coalesced traces
-        for coalesced_traces in trace_utils::coalesce_send_data(&traces) {
+        // Since we return the original traces on error, we need to clone them before coalescing
+        let traces_clone = traces.clone();
+
+        for coalesced_traces in trace_utils::coalesce_send_data(traces) {
             match coalesced_traces
                 .send_proxy(self.config.proxy_url.as_deref())
                 .await

--- a/crates/datadog-trace-agent/src/trace_flusher.rs
+++ b/crates/datadog-trace-agent/src/trace_flusher.rs
@@ -97,10 +97,8 @@ impl TraceFlusher for ServerlessTraceFlusher {
         }
         debug!("Flushing {} traces", traces.len());
 
-        // Since we return the original traces on error, we need to clone them before coalescing
-        let traces_clone = traces.clone();
-
-        for coalesced_traces in trace_utils::coalesce_send_data(traces) {
+        // Process and send coalesced traces
+        for coalesced_traces in trace_utils::coalesce_send_data(&traces) {
             match coalesced_traces
                 .send_proxy(self.config.proxy_url.as_deref())
                 .await

--- a/crates/dogstatsd/src/datadog.rs
+++ b/crates/dogstatsd/src/datadog.rs
@@ -304,7 +304,7 @@ pub(crate) struct Point {
     pub(crate) value: f64,
 }
 
-#[derive(Debug, Serialize)]
+#[derive(Debug, Serialize, Clone)]
 /// A named resource
 pub(crate) struct Resource {
     /// The name of this resource
@@ -335,7 +335,7 @@ impl Serialize for DdMetricKind {
     }
 }
 
-#[derive(Debug, Serialize)]
+#[derive(Debug, Serialize, Clone)]
 #[allow(clippy::struct_field_names)]
 /// A named collection of `Point` instances.
 pub(crate) struct Metric {
@@ -351,7 +351,7 @@ pub(crate) struct Metric {
     pub(crate) tags: Vec<String>,
 }
 
-#[derive(Debug, Serialize)]
+#[derive(Debug, Serialize, Clone)]
 /// A collection of metrics as defined by the Datadog Metrics API.
 // NOTE we have a number of `Vec` instances in this implementation that could
 // otherwise be arrays, given that we have constants. Serializing to JSON would


### PR DESCRIPTION
### What does this PR do?
Modifies the trace flusher and metric flusher to return vecs of data which can be resubmitted in the event of an intermittent failure due to the start/stop behavior of serverless functions.
<!-- A brief description of the change being made with this pull request. -->

### Motivation
Allows us to redrive data outside of a typical retry loop

### Additional Notes

<!-- Any other relevant context that would be helpful. -->

### Describe how to test/QA your changes

<!-- How was the change validated? Are there automated tests to prevent regressions? -->
