### PR TITLE
Refactor metrics flushing

### DIFF
--- a/crates/dogstatsd/src/datadog.rs
+++ b/crates/dogstatsd/src/datadog.rs
@@ -164,6 +164,7 @@ impl DdApi {
 
     /// Ship a serialized series to the API, blocking
     pub async fn ship_series(&self, series: &Series) -> Result<Response, ShippingError> {
+        debug!("=== shipping serialized series to endpoint: {} ===", &self.metrics_intake_url_prefix);
         let url = format!("{}/api/v2/series", &self.metrics_intake_url_prefix);
         let safe_body = serde_json::to_vec(&series)
             .map_err(|e| ShippingError::Payload(format!("Failed to serialize series: {e}")))?;
@@ -175,6 +176,7 @@ impl DdApi {
         &self,
         sketches: &SketchPayload,
     ) -> Result<Response, ShippingError> {
+        debug!("=== shipping distributions to endpoint: {} ===", &self.metrics_intake_url_prefix);
         let url = format!("{}/api/beta/sketches", &self.metrics_intake_url_prefix);
         let safe_body = sketches
             .write_to_bytes()
@@ -199,6 +201,7 @@ impl DdApi {
         body: Vec<u8>,
         content_type: &str,
     ) -> Result<Response, ShippingError> {
+        debug!("=== shipping data to endpoint: {} ===", &self.metrics_intake_url_prefix);
         let client = &self
             .client
             .as_ref()
@@ -228,6 +231,7 @@ impl DdApi {
 
         let elapsed = start.elapsed();
         debug!("Request to {} took {}ms", url, elapsed.as_millis());
+        debug!("=== completed shipping data to endpoint: {} ===", &self.metrics_intake_url_prefix);
         resp
     }
 

--- a/crates/dogstatsd/src/datadog.rs
+++ b/crates/dogstatsd/src/datadog.rs
@@ -164,7 +164,6 @@ impl DdApi {
 
     /// Ship a serialized series to the API, blocking
     pub async fn ship_series(&self, series: &Series) -> Result<Response, ShippingError> {
-        debug!("=== shipping serialized series to endpoint: {} ===", &self.metrics_intake_url_prefix);
         let url = format!("{}/api/v2/series", &self.metrics_intake_url_prefix);
         let safe_body = serde_json::to_vec(&series)
             .map_err(|e| ShippingError::Payload(format!("Failed to serialize series: {e}")))?;
@@ -176,7 +175,6 @@ impl DdApi {
         &self,
         sketches: &SketchPayload,
     ) -> Result<Response, ShippingError> {
-        debug!("=== shipping distributions to endpoint: {} ===", &self.metrics_intake_url_prefix);
         let url = format!("{}/api/beta/sketches", &self.metrics_intake_url_prefix);
         let safe_body = sketches
             .write_to_bytes()
@@ -201,7 +199,6 @@ impl DdApi {
         body: Vec<u8>,
         content_type: &str,
     ) -> Result<Response, ShippingError> {
-        debug!("=== shipping data to endpoint: {} ===", &self.metrics_intake_url_prefix);
         let client = &self
             .client
             .as_ref()
@@ -231,7 +228,6 @@ impl DdApi {
 
         let elapsed = start.elapsed();
         debug!("Request to {} took {}ms", url, elapsed.as_millis());
-        debug!("=== completed shipping data to endpoint: {} ===", &self.metrics_intake_url_prefix);
         resp
     }
 

--- a/crates/dogstatsd/src/flusher.rs
+++ b/crates/dogstatsd/src/flusher.rs
@@ -13,6 +13,15 @@ pub struct Flusher {
     aggregator: Arc<Mutex<Aggregator>>,
 }
 
+impl Clone for Flusher {
+    fn clone(&self) -> Self {
+        Flusher {
+            dd_api: self.dd_api.clone(),
+            aggregator: Arc::clone(&self.aggregator),
+        }
+    }
+}
+
 pub struct FlusherConfig {
     pub api_key: String,
     pub aggregator: Arc<Mutex<Aggregator>>,

--- a/crates/dogstatsd/src/flusher.rs
+++ b/crates/dogstatsd/src/flusher.rs
@@ -54,8 +54,7 @@ impl Flusher {
         Vec<crate::datadog::Series>,
         Vec<datadog_protos::metrics::SketchPayload>,
     )> {
-        // Collect metrics from the aggregator
-        let (series, sketches) = {
+        let (series, distributions) = {
             #[allow(clippy::expect_used)]
             let mut aggregator = self.aggregator.lock().expect("lock poisoned");
             (
@@ -63,7 +62,7 @@ impl Flusher {
                 aggregator.consume_distributions(),
             )
         };
-        self.flush_metrics(series, sketches).await
+        self.flush_metrics(series, distributions).await
     }
 
     /// Flush given batch of metrics

--- a/crates/dogstatsd/src/flusher.rs
+++ b/crates/dogstatsd/src/flusher.rs
@@ -66,39 +66,26 @@ impl Flusher {
         self.flush_metrics(series, sketches).await
     }
 
-    /// Flush explicitly provided metrics
+    // /// Flush explicitly provided metrics
+    // pub async fn flush_metrics(
+    //     &mut self,
+    //     series: Vec<crate::datadog::Series>,
+    //     sketches: Vec<datadog_protos::metrics::SketchPayload>,
+    // ) -> Option<(
+    //     Vec<crate::datadog::Series>,
+    //     Vec<datadog_protos::metrics::SketchPayload>,
+    // )> {
+    //     self.flush_with_retries(series, sketches, None, None).await
+    // }
+
     pub async fn flush_metrics(
         &mut self,
-        series: Vec<crate::datadog::Series>,
-        sketches: Vec<datadog_protos::metrics::SketchPayload>,
+        all_series: Vec<crate::datadog::Series>,
+        all_distributions: Vec<datadog_protos::metrics::SketchPayload>,
     ) -> Option<(
         Vec<crate::datadog::Series>,
         Vec<datadog_protos::metrics::SketchPayload>,
     )> {
-        self.flush_with_retries(series, sketches, None, None).await
-    }
-
-    pub async fn flush_with_retries(
-        &mut self,
-        series: Vec<crate::datadog::Series>,
-        sketches: Vec<datadog_protos::metrics::SketchPayload>,
-        retry_series: Option<Vec<crate::datadog::Series>>,
-        retry_sketches: Option<Vec<datadog_protos::metrics::SketchPayload>>,
-    ) -> Option<(
-        Vec<crate::datadog::Series>,
-        Vec<datadog_protos::metrics::SketchPayload>,
-    )> {
-        let (all_series, all_distributions) = if retry_series.is_some() || retry_sketches.is_some()
-        {
-            // Use the provided metrics for retry
-            (
-                retry_series.unwrap_or_default(),
-                retry_sketches.unwrap_or_default(),
-            )
-        } else {
-            (series, sketches)
-        };
-
         let n_series = all_series.len();
         let n_distributions = all_distributions.len();
 


### PR DESCRIPTION
### What does this PR do?

<!-- A brief description of the change being made with this pull request. -->
This PR refactors how we flush metrics by changing `flush_with_retries` to `flush_metrics` that always take in batches of series and sketches to flush, rather than consuming data directly from the aggregator. 

### Motivation

<!-- Why is this change needed? Link any related Jira cards here. -->
The previous `flush_with_retries` method was responsible for two things:
1. Deciding whether to pull the new batch of metrics from the aggregator or retry previously failed batches
2. Flushing either the new series and distributions _or_ retry series and distributions

This PR removes the logic of deciding which metrics to flush from this function. Since we want to flush a copy of a metrics batch to each endpoints for dual shipping, we can now do that using `flush_metrics`:
- `flush_metrics` is only responsible for flushing the provided batches (this could be new batches or retry batches)
- `flush` now reads from the aggregator and calls `flush_metrics` with new batches of data to maintain the existing behavior of `flush`

### Additional Notes

<!-- Any other relevant context that would be helpful. -->
The lambda extension already handles the logic of determining when there are [metrics to retry sending](https://github.com/DataDog/datadog-lambda-extension/blob/dd534df3ea5987f3cc18bccbddd8f38445d9322c/bottlecap/src/bin/bottlecap/main.rs#L154C9-L178C10). So this PR removes the extra logic in dogstatsd to conditionally decide whether to flush new data or retries, as we now always know what data we are flushing when calling the method.

### Describe how to test/QA your changes
Build the Lambda Extension referencing this branch's latest commit for dogstatsd

<!-- How was the change validated? Are there automated tests to prevent regressions? -->
