### PR TITLE
feat: Defer DD API key resolution to flushing time

### DIFF
--- a/crates/datadog-serverless-compat/src/main.rs
+++ b/crates/datadog-serverless-compat/src/main.rs
@@ -204,8 +204,8 @@ async fn start_dogstatsd(
             #[allow(clippy::expect_used)]
             let metrics_flusher = Flusher::new(FlusherConfig {
                 api_key_factory: Arc::new(move || {
-                    let key = dd_api_key.clone();
-                    Box::pin(async move { key })
+                    let api_key = dd_api_key.clone();
+                    Box::pin(async move { api_key })
                 }),
                 aggregator: Arc::clone(&metrics_aggr),
                 metrics_intake_url_prefix: MetricsIntakeUrlPrefix::new(

--- a/crates/datadog-serverless-compat/src/main.rs
+++ b/crates/datadog-serverless-compat/src/main.rs
@@ -203,7 +203,10 @@ async fn start_dogstatsd(
         Some(dd_api_key) => {
             #[allow(clippy::expect_used)]
             let metrics_flusher = Flusher::new(FlusherConfig {
-                api_key: dd_api_key,
+                api_key_factory: Arc::new(move || {
+                    let key = dd_api_key.clone();
+                    Box::pin(async move { key })
+                }),
                 aggregator: Arc::clone(&metrics_aggr),
                 metrics_intake_url_prefix: MetricsIntakeUrlPrefix::new(
                     Some(Site::new(dd_site).expect("Failed to parse site")),

--- a/crates/dogstatsd/src/flusher.rs
+++ b/crates/dogstatsd/src/flusher.rs
@@ -60,6 +60,7 @@ impl Flusher {
             ));
         }
 
+        #[allow(clippy::expect_used)]
         self.dd_api
             .as_ref()
             .expect("dd_api should be initialized by this point")

--- a/crates/dogstatsd/src/flusher.rs
+++ b/crates/dogstatsd/src/flusher.rs
@@ -60,7 +60,7 @@ impl Flusher {
             ));
         }
 
-        self.dd_api.as_ref().unwrap()
+        self.dd_api.as_ref().expect("dd_api should be initialized by this point")
     }
 
     /// Flush metrics from the aggregator

--- a/crates/dogstatsd/src/flusher.rs
+++ b/crates/dogstatsd/src/flusher.rs
@@ -15,7 +15,7 @@ pub type ApiKeyFactory =
 
 #[derive(Clone)]
 pub struct Flusher {
-    // Accept a future so the API keyresolution is deferred until the flush happens
+    // Accept a future so the API key resolution is deferred until the flush happens
     api_key_factory: ApiKeyFactory,
     metrics_intake_url_prefix: MetricsIntakeUrlPrefix,
     https_proxy: Option<String>,

--- a/crates/dogstatsd/src/flusher.rs
+++ b/crates/dogstatsd/src/flusher.rs
@@ -107,7 +107,7 @@ impl Flusher {
             let mut had_shipping_error = false;
             for a_batch in series {
                 let (continue_shipping, should_retry) =
-                    { should_try_next_batch(dd_api_clone.ship_series(&a_batch).await).await };
+                    should_try_next_batch(dd_api_clone.ship_series(&a_batch).await).await;
                 if should_retry {
                     failed.push(a_batch);
                     had_shipping_error = true;
@@ -124,9 +124,8 @@ impl Flusher {
             let mut failed = Vec::new();
             let mut had_shipping_error = false;
             for a_batch in distributions {
-                let (continue_shipping, should_retry) = {
-                    should_try_next_batch(dd_api_clone.ship_distributions(&a_batch).await).await
-                };
+                let (continue_shipping, should_retry) =
+                    should_try_next_batch(dd_api_clone.ship_distributions(&a_batch).await).await;
                 if should_retry {
                     failed.push(a_batch);
                     had_shipping_error = true;

--- a/crates/dogstatsd/src/flusher.rs
+++ b/crates/dogstatsd/src/flusher.rs
@@ -60,7 +60,9 @@ impl Flusher {
             ));
         }
 
-        self.dd_api.as_ref().expect("dd_api should be initialized by this point")
+        self.dd_api
+            .as_ref()
+            .expect("dd_api should be initialized by this point")
     }
 
     /// Flush metrics from the aggregator

--- a/crates/dogstatsd/tests/integration_test.rs
+++ b/crates/dogstatsd/tests/integration_test.rs
@@ -7,7 +7,7 @@ use dogstatsd::{
     constants::CONTEXTS,
     datadog::{DdDdUrl, MetricsIntakeUrlPrefix, MetricsIntakeUrlPrefixOverride},
     dogstatsd::{DogStatsD, DogStatsDConfig},
-    flusher::{Flusher, FlusherConfig},
+    flusher::{Flusher, FlusherConfig, ApiKeyFactory},
 };
 use mockito::Server;
 use std::sync::{Arc, Mutex};
@@ -40,8 +40,14 @@ async fn dogstatsd_server_ships_series() {
 
     let _ = start_dogstatsd(&metrics_aggr).await;
 
+    let api_key_factory: ApiKeyFactory = Arc::new(|| {
+        Box::pin(async move {
+            "mock-api-key".to_string()
+        })
+    });
+
     let mut metrics_flusher = Flusher::new(FlusherConfig {
-        api_key: "mock-api-key".to_string(),
+        api_key_factory,
         aggregator: Arc::clone(&metrics_aggr),
         metrics_intake_url_prefix: MetricsIntakeUrlPrefix::new(
             None,

--- a/crates/dogstatsd/tests/integration_test.rs
+++ b/crates/dogstatsd/tests/integration_test.rs
@@ -7,7 +7,7 @@ use dogstatsd::{
     constants::CONTEXTS,
     datadog::{DdDdUrl, MetricsIntakeUrlPrefix, MetricsIntakeUrlPrefixOverride},
     dogstatsd::{DogStatsD, DogStatsDConfig},
-    flusher::{Flusher, FlusherConfig, ApiKeyFactory},
+    flusher::{ApiKeyFactory, Flusher, FlusherConfig},
 };
 use mockito::Server;
 use std::sync::{Arc, Mutex};
@@ -40,11 +40,8 @@ async fn dogstatsd_server_ships_series() {
 
     let _ = start_dogstatsd(&metrics_aggr).await;
 
-    let api_key_factory: ApiKeyFactory = Arc::new(|| {
-        Box::pin(async move {
-            "mock-api-key".to_string()
-        })
-    });
+    let api_key_factory: ApiKeyFactory =
+        Arc::new(|| Box::pin(async move { "mock-api-key".to_string() }));
 
     let mut metrics_flusher = Flusher::new(FlusherConfig {
         api_key_factory,


### PR DESCRIPTION
### What does this PR do?

<!-- A brief description of the change being made with this pull request. -->

Make dogstatsd `Flusher` accept a future for the API key instead of the resolved API key string.
The API key future is awaited/resolved at flushing time, instead of by the caller when flusher is initialized.

### Motivation

<!-- Why is this change needed? Link any related Jira cards here. -->

From @astuyve:
> today we basically block/await on that decrypt call before we can call /next
so if we can instead make that async and then resolve the future only when we need to flush data, that can be a big win for many customers.

https://datadoghq.atlassian.net/browse/SVLS-6995

### Additional Notes

<!-- Any other relevant context that would be helpful. -->

This is my first Rust PR. Feel free to throw tons of comments at me!

### Describe how to test/QA your changes

<!-- How was the change validated? Are there automated tests to prevent regressions? -->
Passed the automated tests.
No manual test for now. Will test it after Bottlecap code is updated as well.