### PR TITLE
feat: Add helper functions to ApiKeyFactory struct

### DIFF
--- a/crates/datadog-serverless-compat/src/main.rs
+++ b/crates/datadog-serverless-compat/src/main.rs
@@ -203,10 +203,10 @@ async fn start_dogstatsd(
         Some(dd_api_key) => {
             #[allow(clippy::expect_used)]
             let metrics_flusher = Flusher::new(FlusherConfig {
-                api_key_factory: ApiKeyFactory::new(Arc::new(move || {
+                api_key_factory: Arc::new(ApiKeyFactory::new(Arc::new(move || {
                     let api_key = dd_api_key.clone();
                     Box::pin(async move { api_key })
-                })),
+                }))),
                 aggregator: Arc::clone(&metrics_aggr),
                 metrics_intake_url_prefix: MetricsIntakeUrlPrefix::new(
                     Some(Site::new(dd_site).expect("Failed to parse site")),

--- a/crates/datadog-serverless-compat/src/main.rs
+++ b/crates/datadog-serverless-compat/src/main.rs
@@ -27,11 +27,11 @@ use datadog_trace_utils::{config_utils::read_cloud_env, trace_utils::Environment
 
 use dogstatsd::{
     aggregator::Aggregator as MetricsAggregator,
+    api_key::ApiKeyFactory,
     constants::CONTEXTS,
     datadog::{MetricsIntakeUrlPrefix, RetryStrategy, Site},
     dogstatsd::{DogStatsD, DogStatsDConfig},
     flusher::{Flusher, FlusherConfig},
-    api_key::ApiKeyFactory,
 };
 
 use dogstatsd::metric::{SortedTags, EMPTY_TAGS};

--- a/crates/datadog-serverless-compat/src/main.rs
+++ b/crates/datadog-serverless-compat/src/main.rs
@@ -30,7 +30,7 @@ use dogstatsd::{
     constants::CONTEXTS,
     datadog::{MetricsIntakeUrlPrefix, RetryStrategy, Site},
     dogstatsd::{DogStatsD, DogStatsDConfig},
-    flusher::{Flusher, FlusherConfig},
+    flusher::{ApiKeyFactory, Flusher, FlusherConfig},
 };
 
 use dogstatsd::metric::{SortedTags, EMPTY_TAGS};
@@ -203,10 +203,10 @@ async fn start_dogstatsd(
         Some(dd_api_key) => {
             #[allow(clippy::expect_used)]
             let metrics_flusher = Flusher::new(FlusherConfig {
-                api_key_factory: Arc::new(move || {
+                api_key_factory: ApiKeyFactory::new(Arc::new(move || {
                     let api_key = dd_api_key.clone();
                     Box::pin(async move { api_key })
-                }),
+                })),
                 aggregator: Arc::clone(&metrics_aggr),
                 metrics_intake_url_prefix: MetricsIntakeUrlPrefix::new(
                     Some(Site::new(dd_site).expect("Failed to parse site")),

--- a/crates/datadog-serverless-compat/src/main.rs
+++ b/crates/datadog-serverless-compat/src/main.rs
@@ -30,7 +30,8 @@ use dogstatsd::{
     constants::CONTEXTS,
     datadog::{MetricsIntakeUrlPrefix, RetryStrategy, Site},
     dogstatsd::{DogStatsD, DogStatsDConfig},
-    flusher::{ApiKeyFactory, Flusher, FlusherConfig},
+    flusher::{Flusher, FlusherConfig},
+    api_key::ApiKeyFactory,
 };
 
 use dogstatsd::metric::{SortedTags, EMPTY_TAGS};
@@ -203,10 +204,7 @@ async fn start_dogstatsd(
         Some(dd_api_key) => {
             #[allow(clippy::expect_used)]
             let metrics_flusher = Flusher::new(FlusherConfig {
-                api_key_factory: Arc::new(ApiKeyFactory::new(Arc::new(move || {
-                    let api_key = dd_api_key.clone();
-                    Box::pin(async move { api_key })
-                }))),
+                api_key_factory: Arc::new(ApiKeyFactory::new_with_api_key(&dd_api_key)),
                 aggregator: Arc::clone(&metrics_aggr),
                 metrics_intake_url_prefix: MetricsIntakeUrlPrefix::new(
                     Some(Site::new(dd_site).expect("Failed to parse site")),

--- a/crates/datadog-serverless-compat/src/main.rs
+++ b/crates/datadog-serverless-compat/src/main.rs
@@ -204,7 +204,7 @@ async fn start_dogstatsd(
         Some(dd_api_key) => {
             #[allow(clippy::expect_used)]
             let metrics_flusher = Flusher::new(FlusherConfig {
-                api_key_factory: Arc::new(ApiKeyFactory::new_from_static_key(&dd_api_key)),
+                api_key_factory: Arc::new(ApiKeyFactory::new(&dd_api_key)),
                 aggregator: Arc::clone(&metrics_aggr),
                 metrics_intake_url_prefix: MetricsIntakeUrlPrefix::new(
                     Some(Site::new(dd_site).expect("Failed to parse site")),

--- a/crates/datadog-serverless-compat/src/main.rs
+++ b/crates/datadog-serverless-compat/src/main.rs
@@ -204,7 +204,7 @@ async fn start_dogstatsd(
         Some(dd_api_key) => {
             #[allow(clippy::expect_used)]
             let metrics_flusher = Flusher::new(FlusherConfig {
-                api_key_factory: Arc::new(ApiKeyFactory::new_with_api_key(&dd_api_key)),
+                api_key_factory: Arc::new(ApiKeyFactory::new_from_static_key(&dd_api_key)),
                 aggregator: Arc::clone(&metrics_aggr),
                 metrics_intake_url_prefix: MetricsIntakeUrlPrefix::new(
                     Some(Site::new(dd_site).expect("Failed to parse site")),

--- a/crates/dogstatsd/src/api_key.rs
+++ b/crates/dogstatsd/src/api_key.rs
@@ -1,0 +1,73 @@
+use std::{future::Future, pin::Pin};
+use std::sync::Arc;
+use tokio::sync::OnceCell;
+use std::fmt::Debug;
+
+pub type ApiKeyFactoryFn =
+    Arc<dyn Fn() -> Pin<Box<dyn Future<Output = String> + Send>> + Send + Sync>;
+
+enum ApiKeyFactoryInner {
+    Static(String),
+    Dynamic {
+        resolve_key_fn: ApiKeyFactoryFn,
+        api_key: OnceCell<String>,
+    },
+}
+
+#[derive(Clone)]
+pub struct ApiKeyFactory {
+    inner: Arc<ApiKeyFactoryInner>
+}
+
+impl ApiKeyFactory {
+    pub fn new_with_fn(resolve_key_fn: ApiKeyFactoryFn) -> Self {
+        Self {
+            inner: Arc::new(ApiKeyFactoryInner::Dynamic {
+                resolve_key_fn,
+                api_key: OnceCell::new(),
+            }),
+        }
+    }
+
+    pub fn new_with_api_key(api_key: &str) -> Self {
+        Self {
+            inner: Arc::new(ApiKeyFactoryInner::Static(api_key.to_string())),
+        }
+    }
+
+    pub async fn get_api_key(&self) -> &str {
+        match self.inner.as_ref() {
+            ApiKeyFactoryInner::Static(api_key) => api_key,
+            ApiKeyFactoryInner::Dynamic { resolve_key_fn, api_key } => {
+                api_key.get_or_init(|| async { (resolve_key_fn)().await }).await
+            }
+        }
+    }
+}
+
+impl Debug for ApiKeyFactory {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "ApiKeyFactory")
+    }
+}
+
+#[cfg(test)]
+pub mod tests {
+    use crate::api_key::ApiKeyFactory;
+    use std::sync::Arc;
+
+    #[tokio::test]
+    async fn new_with_fn() {
+        let api_key_factory = Arc::new(ApiKeyFactory::new_with_fn(Arc::new(move || {
+            let api_key = "mock-api-key".to_string();
+            Box::pin(async move { api_key })
+        })));
+        assert_eq!(api_key_factory.get_api_key().await, "mock-api-key");
+    }
+
+    #[tokio::test]
+    async fn new_with_api_key() {
+        let api_key_factory = ApiKeyFactory::new_with_api_key("mock-api-key");
+        assert_eq!(api_key_factory.get_api_key().await, "mock-api-key");
+    }
+}

--- a/crates/dogstatsd/src/api_key.rs
+++ b/crates/dogstatsd/src/api_key.rs
@@ -16,15 +16,17 @@ pub enum ApiKeyFactory {
 }
 
 impl ApiKeyFactory {
+    /// Create a new `ApiKeyFactory` with a static API key.
+    pub fn new(api_key: &str) -> Self {
+        Self::Static(api_key.to_string())
+    }
+
+    /// Create a new `ApiKeyFactory` with a dynamic API key resolver function.
     pub fn new_from_resolver(resolver_fn: ApiKeyResolverFn) -> Self {
         Self::Dynamic {
             resolver_fn,
             api_key: Arc::new(OnceCell::new()),
         }
-    }
-
-    pub fn new(api_key: &str) -> Self {
-        Self::Static(api_key.to_string())
     }
 
     pub async fn get_api_key(&self) -> &str {

--- a/crates/dogstatsd/src/api_key.rs
+++ b/crates/dogstatsd/src/api_key.rs
@@ -55,17 +55,17 @@ pub mod tests {
     use super::*;
 
     #[tokio::test]
-    async fn new_from_resolver() {
-        let api_key_factory = Arc::new(ApiKeyFactory::new_from_resolver(Arc::new(move || {
-            let api_key = "mock-api-key".to_string();
-            Box::pin(async move { api_key })
-        })));
+    async fn test_new() {
+        let api_key_factory = ApiKeyFactory::new("mock-api-key");
         assert_eq!(api_key_factory.get_api_key().await, "mock-api-key");
     }
 
     #[tokio::test]
-    async fn new() {
-        let api_key_factory = ApiKeyFactory::new("mock-api-key");
+    async fn test_new_from_resolver() {
+        let api_key_factory = Arc::new(ApiKeyFactory::new_from_resolver(Arc::new(move || {
+            let api_key = "mock-api-key".to_string();
+            Box::pin(async move { api_key })
+        })));
         assert_eq!(api_key_factory.get_api_key().await, "mock-api-key");
     }
 }

--- a/crates/dogstatsd/src/api_key.rs
+++ b/crates/dogstatsd/src/api_key.rs
@@ -52,8 +52,7 @@ impl Debug for ApiKeyFactory {
 
 #[cfg(test)]
 pub mod tests {
-    use crate::api_key::ApiKeyFactory;
-    use std::sync::Arc;
+    use super::*;
 
     #[tokio::test]
     async fn new_from_resolver() {

--- a/crates/dogstatsd/src/api_key.rs
+++ b/crates/dogstatsd/src/api_key.rs
@@ -3,7 +3,8 @@ use std::sync::Arc;
 use std::{future::Future, pin::Pin};
 use tokio::sync::OnceCell;
 
-pub type ApiKeyResolverFn = Arc<dyn Fn() -> Pin<Box<dyn Future<Output = String> + Send>> + Send + Sync>;
+pub type ApiKeyResolverFn =
+    Arc<dyn Fn() -> Pin<Box<dyn Future<Output = String> + Send>> + Send + Sync>;
 
 #[derive(Clone)]
 pub enum ApiKeyFactory {

--- a/crates/dogstatsd/src/api_key.rs
+++ b/crates/dogstatsd/src/api_key.rs
@@ -23,7 +23,7 @@ impl ApiKeyFactory {
         }
     }
 
-    pub fn new_from_static_key(api_key: &str) -> Self {
+    pub fn new(api_key: &str) -> Self {
         Self::Static(api_key.to_string())
     }
 
@@ -63,8 +63,8 @@ pub mod tests {
     }
 
     #[tokio::test]
-    async fn new_from_static_key() {
-        let api_key_factory = ApiKeyFactory::new_from_static_key("mock-api-key");
+    async fn new() {
+        let api_key_factory = ApiKeyFactory::new("mock-api-key");
         assert_eq!(api_key_factory.get_api_key().await, "mock-api-key");
     }
 }

--- a/crates/dogstatsd/src/api_key.rs
+++ b/crates/dogstatsd/src/api_key.rs
@@ -1,7 +1,7 @@
-use std::{future::Future, pin::Pin};
-use std::sync::Arc;
-use tokio::sync::OnceCell;
 use std::fmt::Debug;
+use std::sync::Arc;
+use std::{future::Future, pin::Pin};
+use tokio::sync::OnceCell;
 
 pub type ApiKeyResolverFn =
     Arc<dyn Fn() -> Pin<Box<dyn Future<Output = String> + Send>> + Send + Sync>;
@@ -16,7 +16,7 @@ enum ApiKeyFactoryInner {
 
 #[derive(Clone)]
 pub struct ApiKeyFactory {
-    inner: Arc<ApiKeyFactoryInner>
+    inner: Arc<ApiKeyFactoryInner>,
 }
 
 impl ApiKeyFactory {
@@ -38,8 +38,13 @@ impl ApiKeyFactory {
     pub async fn get_api_key(&self) -> &str {
         match self.inner.as_ref() {
             ApiKeyFactoryInner::Static(api_key) => api_key,
-            ApiKeyFactoryInner::Dynamic { resolver_fn, api_key } => {
-                api_key.get_or_init(|| async { (resolver_fn)().await }).await
+            ApiKeyFactoryInner::Dynamic {
+                resolver_fn,
+                api_key,
+            } => {
+                api_key
+                    .get_or_init(|| async { (resolver_fn)().await })
+                    .await
             }
         }
     }

--- a/crates/dogstatsd/src/flusher.rs
+++ b/crates/dogstatsd/src/flusher.rs
@@ -30,10 +30,8 @@ impl ApiKeyFactory {
 
     pub async fn get_api_key(&self) -> &str {
         self.api_key
-        .get_or_init(async || {
-            (self.resolve_key_fn)().await
-        })
-        .await
+            .get_or_init(|| async { (self.resolve_key_fn)().await })
+            .await
     }
 }
 

--- a/crates/dogstatsd/src/flusher.rs
+++ b/crates/dogstatsd/src/flusher.rs
@@ -38,7 +38,7 @@ impl ApiKeyFactory {
 #[derive(Clone)]
 pub struct Flusher {
     // Accept a future so the API key resolution is deferred until the flush happens
-    api_key_factory: ApiKeyFactory,
+    api_key_factory: Arc<ApiKeyFactory>,
     metrics_intake_url_prefix: MetricsIntakeUrlPrefix,
     https_proxy: Option<String>,
     timeout: Duration,
@@ -48,7 +48,7 @@ pub struct Flusher {
 }
 
 pub struct FlusherConfig {
-    pub api_key_factory: ApiKeyFactory,
+    pub api_key_factory: Arc<ApiKeyFactory>,
     pub aggregator: Arc<Mutex<Aggregator>>,
     pub metrics_intake_url_prefix: MetricsIntakeUrlPrefix,
     pub https_proxy: Option<String>,
@@ -60,7 +60,7 @@ pub struct FlusherConfig {
 impl Flusher {
     pub fn new(config: FlusherConfig) -> Self {
         Flusher {
-            api_key_factory: config.api_key_factory,
+            api_key_factory: Arc::clone(&config.api_key_factory),
             metrics_intake_url_prefix: config.metrics_intake_url_prefix,
             https_proxy: config.https_proxy,
             timeout: config.timeout,

--- a/crates/dogstatsd/src/flusher.rs
+++ b/crates/dogstatsd/src/flusher.rs
@@ -1,8 +1,8 @@
 // Copyright 2023-Present Datadog, Inc. https://www.datadoghq.com/
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::api_key::ApiKeyFactory;
 use crate::aggregator::Aggregator;
+use crate::api_key::ApiKeyFactory;
 use crate::datadog::{DdApi, MetricsIntakeUrlPrefix, RetryStrategy};
 use reqwest::{Response, StatusCode};
 use std::sync::{Arc, Mutex};
@@ -56,7 +56,9 @@ impl Flusher {
             ));
         }
 
-        self.dd_api.as_ref().expect("dd_api should have been initialized")
+        self.dd_api
+            .as_ref()
+            .expect("dd_api should have been initialized")
     }
 
     /// Flush metrics from the aggregator

--- a/crates/dogstatsd/src/flusher.rs
+++ b/crates/dogstatsd/src/flusher.rs
@@ -89,7 +89,7 @@ impl Flusher {
             ));
         }
 
-        self.dd_api.as_ref().unwrap()
+        self.dd_api.as_ref().expect("dd_api should have been initialized")
     }
 
     /// Flush metrics from the aggregator

--- a/crates/dogstatsd/src/flusher.rs
+++ b/crates/dogstatsd/src/flusher.rs
@@ -56,6 +56,7 @@ impl Flusher {
             ));
         }
 
+        #[allow(clippy::expect_used)]
         self.dd_api
             .as_ref()
             .expect("dd_api should have been initialized")

--- a/crates/dogstatsd/src/flusher.rs
+++ b/crates/dogstatsd/src/flusher.rs
@@ -10,6 +10,7 @@ use std::sync::{Arc, Mutex};
 use std::time::Duration;
 use tracing::{debug, error};
 use tokio::sync::OnceCell;
+use std::fmt::{Debug};
 
 pub type ApiKeyFactoryFn =
     Arc<dyn Fn() -> Pin<Box<dyn Future<Output = String> + Send>> + Send + Sync>;
@@ -32,6 +33,12 @@ impl ApiKeyFactory {
         self.api_key
             .get_or_init(|| async { (self.resolve_key_fn)().await })
             .await
+    }
+}
+
+impl Debug for ApiKeyFactory {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "ApiKeyFactory")
     }
 }
 

--- a/crates/dogstatsd/src/lib.rs
+++ b/crates/dogstatsd/src/lib.rs
@@ -8,6 +8,7 @@
 #![cfg_attr(not(test), deny(clippy::unimplemented))]
 
 pub mod aggregator;
+pub mod api_key;
 pub mod constants;
 pub mod datadog;
 pub mod dogstatsd;

--- a/crates/dogstatsd/tests/integration_test.rs
+++ b/crates/dogstatsd/tests/integration_test.rs
@@ -7,7 +7,8 @@ use dogstatsd::{
     constants::CONTEXTS,
     datadog::{DdDdUrl, MetricsIntakeUrlPrefix, MetricsIntakeUrlPrefixOverride},
     dogstatsd::{DogStatsD, DogStatsDConfig},
-    flusher::{ApiKeyFactory, Flusher, FlusherConfig},
+    flusher::{Flusher, FlusherConfig},
+    api_key::ApiKeyFactory,
 };
 use mockito::Server;
 use std::sync::{Arc, Mutex};
@@ -40,11 +41,10 @@ async fn dogstatsd_server_ships_series() {
 
     let _ = start_dogstatsd(&metrics_aggr).await;
 
-    let api_key_factory: ApiKeyFactory =
-        Arc::new(|| Box::pin(async move { "mock-api-key".to_string() }));
+    let api_key_factory = ApiKeyFactory::new_with_api_key("mock-api-key");
 
     let mut metrics_flusher = Flusher::new(FlusherConfig {
-        api_key_factory,
+        api_key_factory: Arc::new(api_key_factory),
         aggregator: Arc::clone(&metrics_aggr),
         metrics_intake_url_prefix: MetricsIntakeUrlPrefix::new(
             None,

--- a/crates/dogstatsd/tests/integration_test.rs
+++ b/crates/dogstatsd/tests/integration_test.rs
@@ -41,7 +41,7 @@ async fn dogstatsd_server_ships_series() {
 
     let _ = start_dogstatsd(&metrics_aggr).await;
 
-    let api_key_factory = ApiKeyFactory::new_from_static_key("mock-api-key");
+    let api_key_factory = ApiKeyFactory::new("mock-api-key");
 
     let mut metrics_flusher = Flusher::new(FlusherConfig {
         api_key_factory: Arc::new(api_key_factory),

--- a/crates/dogstatsd/tests/integration_test.rs
+++ b/crates/dogstatsd/tests/integration_test.rs
@@ -41,7 +41,7 @@ async fn dogstatsd_server_ships_series() {
 
     let _ = start_dogstatsd(&metrics_aggr).await;
 
-    let api_key_factory = ApiKeyFactory::new_with_api_key("mock-api-key");
+    let api_key_factory = ApiKeyFactory::new_from_static_key("mock-api-key");
 
     let mut metrics_flusher = Flusher::new(FlusherConfig {
         api_key_factory: Arc::new(api_key_factory),

--- a/crates/dogstatsd/tests/integration_test.rs
+++ b/crates/dogstatsd/tests/integration_test.rs
@@ -4,11 +4,11 @@
 use dogstatsd::metric::SortedTags;
 use dogstatsd::{
     aggregator::Aggregator as MetricsAggregator,
+    api_key::ApiKeyFactory,
     constants::CONTEXTS,
     datadog::{DdDdUrl, MetricsIntakeUrlPrefix, MetricsIntakeUrlPrefixOverride},
     dogstatsd::{DogStatsD, DogStatsDConfig},
     flusher::{Flusher, FlusherConfig},
-    api_key::ApiKeyFactory,
 };
 use mockito::Server;
 use std::sync::{Arc, Mutex};


### PR DESCRIPTION
### What does this PR do?

<!-- A brief description of the change being made with this pull request. -->

1. Add helper functions to `ApiKeyFactory` struct, including:
    1. `new_from_resolver()`, which takes in a resolver function and enables lazy resolution
    2. `new_from_static_key()`, which takes in a static api key string slice
    3. `get_api_key()`
2. Move `ApiKeyFactory` related code to a separate module `api_key`

### Motivation

<!-- Why is this change needed? Link any related Jira cards here. -->

As a continuation of https://github.com/DataDog/serverless-components/pull/21.

From @astuyve:
> today we basically block/await on that decrypt call before we can call /next
so if we can instead make that async and then resolve the future only when we need to flush data, that can be a big win for many customers.

https://datadoghq.atlassian.net/browse/SVLS-6995

### Additional Notes

<!-- Any other relevant context that would be helpful. -->

### Describe how to test/QA your changes

<!-- How was the change validated? Are there automated tests to prevent regressions? -->

1. Passed the added automated tests
4. Used it in Lambda extension, which did improve start time. See https://github.com/DataDog/datadog-lambda-extension/pull/717
