### PR TITLE
feat: Make ApiKeyFactory return Option<String>

### DIFF
--- a/crates/dogstatsd/src/flusher.rs
+++ b/crates/dogstatsd/src/flusher.rs
@@ -7,6 +7,7 @@ use crate::datadog::{DdApi, MetricsIntakeUrlPrefix, RetryStrategy};
 use reqwest::{Response, StatusCode};
 use std::sync::{Arc, Mutex};
 use std::time::Duration;
+use tokio::sync::OnceCell;
 use tracing::{debug, error};
 
 #[derive(Clone)]
@@ -18,7 +19,7 @@ pub struct Flusher {
     timeout: Duration,
     retry_strategy: RetryStrategy,
     aggregator: Arc<Mutex<Aggregator>>,
-    dd_api: Option<DdApi>,
+    dd_api: OnceCell<Option<DdApi>>,
 }
 
 pub struct FlusherConfig {
@@ -40,26 +41,29 @@ impl Flusher {
             timeout: config.timeout,
             retry_strategy: config.retry_strategy,
             aggregator: config.aggregator,
-            dd_api: None,
+            dd_api: OnceCell::new(),
         }
     }
 
-    async fn get_dd_api(&mut self) -> &DdApi {
-        if self.dd_api.is_none() {
-            let api_key = self.api_key_factory.get_api_key().await;
-            self.dd_api = Some(DdApi::new(
-                api_key.to_string(),
-                self.metrics_intake_url_prefix.clone(),
-                self.https_proxy.clone(),
-                self.timeout,
-                self.retry_strategy.clone(),
-            ));
-        }
-
-        #[allow(clippy::expect_used)]
+    async fn get_dd_api(&mut self) -> &Option<DdApi> {
         self.dd_api
-            .as_ref()
-            .expect("dd_api should have been initialized")
+            .get_or_init(|| async {
+                let api_key = self.api_key_factory.get_api_key().await;
+                match api_key {
+                    Some(api_key) => Some(DdApi::new(
+                        api_key.to_string(),
+                        self.metrics_intake_url_prefix.clone(),
+                        self.https_proxy.clone(),
+                        self.timeout,
+                        self.retry_strategy.clone(),
+                    )),
+                    None => {
+                        error!("Failed to create dd_api: failed to get API key");
+                        None
+                    }
+                }
+            })
+            .await
     }
 
     /// Flush metrics from the aggregator
@@ -98,7 +102,13 @@ impl Flusher {
         let series_copy = series.clone();
         let distributions_copy = distributions.clone();
 
-        let dd_api = self.get_dd_api().await;
+        let dd_api = match self.get_dd_api().await {
+            None => {
+                error!("Failed to flush metrics: failed to create dd_api");
+                return Some((series_copy, distributions_copy));
+            }
+            Some(dd_api) => dd_api,
+        };
 
         let dd_api_clone = dd_api.clone();
         let series_handle = tokio::spawn(async move {


### PR DESCRIPTION
### What does this PR do?

<!-- A brief description of the change being made with this pull request. -->

1. Right now `ApiKeyFactory` returns `String`. This PR makes it return `Option<String>`.
2. In `Flusher`, if API key resolution fails, then make `flush_metrics()` a no-op by returning early.

### Motivation

<!-- Why is this change needed? Link any related Jira cards here. -->

API key resolution can fail. In this case, we should allow the resolver function to return `None`.

### Additional Notes

<!-- Any other relevant context that would be helpful. -->

### Describe how to test/QA your changes

<!-- How was the change validated? Are there automated tests to prevent regressions? -->
