### PR TITLE
chore: remove miri config from all tests

### DIFF
--- a/crates/datadog-trace-agent/src/env_verifier.rs
+++ b/crates/datadog-trace-agent/src/env_verifier.rs
@@ -349,7 +349,6 @@ mod tests {
     use super::{EnvVerifier, ServerlessEnvVerifier};
 
     #[tokio::test]
-    #[cfg_attr(miri, ignore)]
     async fn test_ensure_gcp_env_false_if_metadata_server_unreachable() {
         struct MockGoogleMetadataClient {}
         #[async_trait]
@@ -369,7 +368,6 @@ mod tests {
     }
 
     #[tokio::test]
-    #[cfg_attr(miri, ignore)]
     async fn test_ensure_gcp_env_false_if_no_server_in_response_headers() {
         struct MockGoogleMetadataClient {}
         #[async_trait]
@@ -392,7 +390,6 @@ mod tests {
     }
 
     #[tokio::test]
-    #[cfg_attr(miri, ignore)]
     async fn test_ensure_gcp_env_if_server_header_not_serverless() {
         struct MockGoogleMetadataClient {}
         #[async_trait]
@@ -417,7 +414,6 @@ mod tests {
     }
 
     #[tokio::test]
-    #[cfg_attr(miri, ignore)]
     async fn test_ensure_gcp_env_true_if_cloud_function_env() {
         struct MockGoogleMetadataClient {}
         #[async_trait]
@@ -460,7 +456,6 @@ mod tests {
     }
 
     #[tokio::test]
-    #[cfg_attr(miri, ignore)]
     async fn test_gcp_verify_environment_timeout_exceeded_gives_unknown_values() {
         struct MockGoogleMetadataClient {}
         #[async_trait]
@@ -511,7 +506,6 @@ mod tests {
     }
 
     #[tokio::test]
-    #[cfg_attr(miri, ignore)]
     async fn test_ensure_azure_env_windows_true() {
         struct MockAzureVerificationClient {}
         #[async_trait]
@@ -527,7 +521,6 @@ mod tests {
     }
 
     #[tokio::test]
-    #[cfg_attr(miri, ignore)]
     async fn test_ensure_azure_env_windows_false() {
         struct MockAzureVerificationClient {}
         #[async_trait]
@@ -550,7 +543,6 @@ mod tests {
     }
 
     #[tokio::test]
-    #[cfg_attr(miri, ignore)]
     async fn test_ensure_azure_env_linux_true() {
         struct MockAzureVerificationClient {}
         #[async_trait]
@@ -566,7 +558,6 @@ mod tests {
     }
 
     #[tokio::test]
-    #[cfg_attr(miri, ignore)]
     async fn test_ensure_azure_env_linux_false() {
         struct MockAzureVerificationClient {}
         #[async_trait]

--- a/crates/datadog-trace-agent/src/http_utils.rs
+++ b/crates/datadog-trace-agent/src/http_utils.rs
@@ -134,7 +134,6 @@ mod tests {
     }
 
     #[tokio::test]
-    #[cfg_attr(miri, ignore)]
     async fn test_request_content_length_missing() {
         let verify_result = verify_request_content_length(&HeaderMap::new(), 1, "Test Prefix");
         assert!(verify_result.is_some());
@@ -149,7 +148,6 @@ mod tests {
     }
 
     #[tokio::test]
-    #[cfg_attr(miri, ignore)]
     async fn test_request_content_length_cant_convert_to_str() {
         let verify_result = verify_request_content_length(
             &create_test_headers_with_content_length("❤❤❤❤❤❤❤"),
@@ -167,7 +165,6 @@ mod tests {
     }
 
     #[tokio::test]
-    #[cfg_attr(miri, ignore)]
     async fn test_request_content_length_cant_convert_to_usize() {
         let verify_result = verify_request_content_length(
             &create_test_headers_with_content_length("not_an_int"),
@@ -185,7 +182,6 @@ mod tests {
     }
 
     #[tokio::test]
-    #[cfg_attr(miri, ignore)]
     async fn test_request_content_length_too_long() {
         let verify_result = verify_request_content_length(
             &create_test_headers_with_content_length("100"),

--- a/crates/datadog-trace-agent/src/trace_processor.rs
+++ b/crates/datadog-trace-agent/src/trace_processor.rs
@@ -202,7 +202,6 @@ mod tests {
     }
 
     #[tokio::test]
-    #[cfg_attr(miri, ignore)]
     async fn test_process_trace() {
         let (tx, mut rx): (
             Sender<trace_utils::SendData>,
@@ -268,7 +267,6 @@ mod tests {
     }
 
     #[tokio::test]
-    #[cfg_attr(miri, ignore)]
     async fn test_process_trace_top_level_span_set() {
         let (tx, mut rx): (
             Sender<trace_utils::SendData>,

--- a/crates/dogstatsd/src/aggregator.rs
+++ b/crates/dogstatsd/src/aggregator.rs
@@ -372,7 +372,6 @@ pub mod tests {
     }
 
     #[test]
-    #[cfg_attr(miri, ignore)]
     fn insertion() {
         let mut aggregator = Aggregator::new(EMPTY_TAGS, 2).unwrap();
 
@@ -387,7 +386,6 @@ pub mod tests {
     }
 
     #[test]
-    #[cfg_attr(miri, ignore)]
     fn distribution_insertion() {
         let mut aggregator = Aggregator::new(EMPTY_TAGS, 2).unwrap();
 
@@ -402,7 +400,6 @@ pub mod tests {
     }
 
     #[test]
-    #[cfg_attr(miri, ignore)]
     fn overflow() {
         let mut aggregator = Aggregator::new(EMPTY_TAGS, 2).unwrap();
         let mut now = std::time::UNIX_EPOCH
@@ -438,7 +435,6 @@ pub mod tests {
 
     #[test]
     #[allow(clippy::float_cmp)]
-    #[cfg_attr(miri, ignore)]
     fn clear() {
         let mut aggregator = Aggregator::new(EMPTY_TAGS, 2).unwrap();
         let mut now = 1656581409;
@@ -475,7 +471,6 @@ pub mod tests {
     }
 
     #[test]
-    #[cfg_attr(miri, ignore)]
     fn to_series() {
         let mut aggregator = Aggregator::new(EMPTY_TAGS, 2).unwrap();
 
@@ -498,7 +493,6 @@ pub mod tests {
     }
 
     #[test]
-    #[cfg_attr(miri, ignore)]
     fn distributions_to_protobuf() {
         let mut aggregator = Aggregator::new(EMPTY_TAGS, 2).unwrap();
 
@@ -516,7 +510,6 @@ pub mod tests {
     }
 
     #[test]
-    #[cfg_attr(miri, ignore)]
     fn consume_distributions_ignore_single_metrics() {
         let mut aggregator = Aggregator::new(EMPTY_TAGS, 1_000).unwrap();
         assert_eq!(aggregator.distributions_to_protobuf().sketches.len(), 0);
@@ -533,7 +526,6 @@ pub mod tests {
     }
 
     #[test]
-    #[cfg_attr(miri, ignore)]
     fn consume_distributions_batch_entries() {
         let max_batch = 5;
         let tot = 12;
@@ -558,7 +550,6 @@ pub mod tests {
     }
 
     #[test]
-    #[cfg_attr(miri, ignore)]
     fn consume_distributions_batch_bytes() {
         let expected_distribution_per_batch = 2;
         let total_number_of_distributions = 5;
@@ -603,7 +594,6 @@ pub mod tests {
     }
 
     #[test]
-    #[cfg_attr(miri, ignore)]
     fn consume_distribution_one_element_bigger_than_max_size() {
         let max_bytes = 1;
         let tot = 5;
@@ -638,7 +628,6 @@ pub mod tests {
     }
 
     #[test]
-    #[cfg_attr(miri, ignore)]
     fn consume_series_ignore_distribution() {
         let mut aggregator = Aggregator::new(EMPTY_TAGS, 1_000).unwrap();
 
@@ -663,7 +652,6 @@ pub mod tests {
     }
 
     #[test]
-    #[cfg_attr(miri, ignore)]
     fn consume_series_batch_entries() {
         let max_batch = 5;
         let tot = 13;
@@ -689,7 +677,6 @@ pub mod tests {
     }
 
     #[test]
-    #[cfg_attr(miri, ignore)]
     fn consume_metrics_batch_bytes() {
         let expected_metrics_per_batch = 2;
         let total_number_of_metrics = 5;
@@ -727,7 +714,6 @@ pub mod tests {
     }
 
     #[test]
-    #[cfg_attr(miri, ignore)]
     fn consume_series_one_element_bigger_than_max_size() {
         let max_bytes = 1;
         let tot = 5;
@@ -754,7 +740,6 @@ pub mod tests {
     }
 
     #[test]
-    #[cfg_attr(miri, ignore)]
     fn distribution_serialized_deserialized() {
         let mut aggregator = Aggregator::new(EMPTY_TAGS, 1_000).unwrap();
 

--- a/crates/dogstatsd/src/dogstatsd.rs
+++ b/crates/dogstatsd/src/dogstatsd.rs
@@ -141,7 +141,6 @@ mod tests {
     use tracing_test::traced_test;
 
     #[tokio::test]
-    #[cfg_attr(miri, ignore)]
     async fn test_dogstatsd_multi_distribution() {
         let locked_aggregator = setup_dogstatsd(
             "single_machine_performance.rouster.api.series_v2.payload_size_bytes:269942|d|T1656581409
@@ -179,7 +178,6 @@ single_machine_performance.rouster.metrics_max_timestamp_latency:1376.90870216|d
     }
 
     #[tokio::test]
-    #[cfg_attr(miri, ignore)]
     async fn test_dogstatsd_multi_metric() {
         let mut now = std::time::UNIX_EPOCH
             .elapsed()
@@ -216,7 +214,6 @@ single_machine_performance.rouster.metrics_max_timestamp_latency:1376.90870216|d
     }
 
     #[tokio::test]
-    #[cfg_attr(miri, ignore)]
     async fn test_dogstatsd_single_metric() {
         let locked_aggregator = setup_dogstatsd("metric123:99123|c|T1656581409").await;
         let aggregator = locked_aggregator.lock().expect("lock poisoned");
@@ -231,7 +228,6 @@ single_machine_performance.rouster.metrics_max_timestamp_latency:1376.90870216|d
 
     #[tokio::test]
     #[traced_test]
-    #[cfg_attr(miri, ignore)]
     async fn test_dogstatsd_filter_service_check() {
         let locked_aggregator = setup_dogstatsd("_sc|servicecheck|0").await;
         let aggregator = locked_aggregator.lock().expect("lock poisoned");
@@ -243,7 +239,6 @@ single_machine_performance.rouster.metrics_max_timestamp_latency:1376.90870216|d
 
     #[tokio::test]
     #[traced_test]
-    #[cfg_attr(miri, ignore)]
     async fn test_dogstatsd_filter_event() {
         let locked_aggregator = setup_dogstatsd("_e{5,10}:event|test event").await;
         let aggregator = locked_aggregator.lock().expect("lock poisoned");

--- a/crates/dogstatsd/src/metric.rs
+++ b/crates/dogstatsd/src/metric.rs
@@ -393,7 +393,6 @@ mod tests {
         // For any valid name, tags et al the parse routine is able to parse an
         // encoded metric line.
         #[test]
-        #[cfg_attr(miri, ignore)]
         fn parse_valid_inputs(
             name in metric_name(),
             values in metric_values(),
@@ -455,7 +454,6 @@ mod tests {
         }
 
         #[test]
-        #[cfg_attr(miri, ignore)]
         fn parse_missing_name_and_value(
             mtype in metric_type(),
             tagset in metric_tagset()
@@ -471,7 +469,6 @@ mod tests {
         }
 
         #[test]
-        #[cfg_attr(miri, ignore)]
         fn parse_invalid_name_and_value_format(
             name in metric_name(),
             values in metric_values(),
@@ -493,7 +490,6 @@ mod tests {
         }
 
         #[test]
-        #[cfg_attr(miri, ignore)]
         fn parse_unsupported_metric_type(
             name in metric_name(),
             values in metric_values(),
@@ -518,7 +514,6 @@ mod tests {
         // For any valid name, tags et al the parse routine is able to parse an
         // encoded metric line.
         #[test]
-        #[cfg_attr(miri, ignore)]
         fn id_consistent(name in metric_name(),
                          mut tags in metric_tags()) {
             let mut tagset1 = String::new();
@@ -550,7 +545,6 @@ mod tests {
         }
 
         #[test]
-        #[cfg_attr(miri, ignore)]
         fn resources_key_val_order(tags in metric_tags()) {
             let sorted_tags = SortedTags { values: tags.into_iter()
                 .map(|(kind, name)| (Ustr::from(&kind), Ustr::from(&name)))
@@ -566,7 +560,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(miri, ignore)]
     fn parse_too_many_tags() {
         // 101
         assert_eq!(
@@ -581,19 +574,16 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(miri, ignore)]
     fn invalid_dogstatsd_no_panic() {
         assert!(parse("somerandomstring|c+a;slda").is_err());
     }
 
     #[test]
-    #[cfg_attr(miri, ignore)]
     fn parse_container_id() {
         assert!(parse("containerid.metric:0|c|#env:dev,client_transport:udp|c:0000000000000000000000000000000000000000000000000000000000000000").is_ok());
     }
 
     #[test]
-    #[cfg_attr(miri, ignore)]
     fn parse_tag_no_value() {
         let result = parse("datadog.tracer.flush_triggered:1|c|#lang:go,lang_version:go1.22.10,_dd.origin:lambda,runtime-id:d66f501c-d09b-4d0d-970f-515235c4eb56,v1.65.1,service:aws.lambda,reason:scheduled");
         assert!(result.is_ok());
@@ -607,7 +597,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(miri, ignore)]
     fn parse_tag_multi_column() {
         let result = parse("datadog.tracer.flush_triggered:1|c|#lang:go:and:something:else");
         assert!(result.is_ok());
@@ -618,7 +607,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(miri, ignore)]
     fn parse_tracer_metric() {
         let input = "datadog.tracer.flush_duration:0.785551|ms|#lang:go,lang_version:go1.23.2,env:redacted_env,_dd.origin:lambda,runtime-id:redacted_runtime,tracer_version:v1.70.1,service:redacted_service,env:redacted_env,service:redacted_service,version:redacted_version";
         let expected_error = "ms".to_string();
@@ -630,7 +618,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(miri, ignore)]
     fn parse_metric_timestamp() {
         // Important to test that we round down to the nearest 10 seconds
         // for our buckets
@@ -647,7 +634,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(miri, ignore)]
     fn parse_metric_no_timestamp() {
         // *wince* this could be a race condition
         // we round the timestamp down to a 10s bucket and I want to test now

--- a/crates/dogstatsd/tests/integration_test.rs
+++ b/crates/dogstatsd/tests/integration_test.rs
@@ -19,7 +19,6 @@ use tokio::{
 use tokio_util::sync::CancellationToken;
 
 #[cfg(test)]
-#[cfg(not(miri))]
 #[tokio::test]
 async fn dogstatsd_server_ships_series() {
     use dogstatsd::datadog::RetryStrategy;
@@ -106,7 +105,6 @@ async fn start_dogstatsd(metrics_aggr: &Arc<Mutex<MetricsAggregator>>) -> Cancel
 }
 
 #[cfg(test)]
-#[cfg(not(miri))]
 #[tokio::test]
 async fn test_send_with_retry_immediate_failure() {
     use dogstatsd::datadog::{DdApi, DdDdUrl, RetryStrategy};
@@ -154,7 +152,6 @@ async fn test_send_with_retry_immediate_failure() {
 }
 
 #[cfg(test)]
-#[cfg(not(miri))]
 #[tokio::test]
 async fn test_send_with_retry_linear_backoff_success() {
     use dogstatsd::datadog::{DdApi, DdDdUrl, RetryStrategy};
@@ -216,7 +213,6 @@ async fn test_send_with_retry_linear_backoff_success() {
 }
 
 #[cfg(test)]
-#[cfg(not(miri))]
 #[tokio::test]
 async fn test_send_with_retry_immediate_failure_after_one_attempt() {
     use dogstatsd::datadog::{DdApi, DdDdUrl, RetryStrategy};


### PR DESCRIPTION
### What does this PR do?

Remove miri ignore from all tests.

### Motivation

No miri tests in this repo so removing the unnecessary config.

### Additional Notes

Miri config was copied when the crates were migrated from libdatadog.

### Describe how to test/QA your changes

<!-- How was the change validated? Are there automated tests to prevent regressions? -->
