### PR TITLE
feat: add tags to config

### DIFF
--- a/crates/datadog-trace-agent/src/trace_processor.rs
+++ b/crates/datadog-trace-agent/src/trace_processor.rs
@@ -125,12 +125,12 @@ impl TraceProcessor for ServerlessTraceProcessor {
         };
 
         // Add function_tags to payload if we can
-        if let Some(function_tags) = &config.function_tags {
+        if let Some(function_tags) = config.tags.function_tags() {
             if let TracerPayloadCollection::V07(ref mut tracer_payloads) = payload {
                 for tracer_payload in tracer_payloads {
                     tracer_payload.tags.insert(
                         TRACER_PAYLOAD_FUNCTION_TAGS_TAG_KEY.to_string(),
-                        function_tags.clone(),
+                        function_tags.to_string(),
                     );
                 }
             }
@@ -164,7 +164,7 @@ mod tests {
     use tokio::sync::mpsc::{self, Receiver, Sender};
 
     use crate::{
-        config::Config,
+        config::{Config, Tags},
         trace_processor::{self, TraceProcessor, TRACER_PAYLOAD_FUNCTION_TAGS_TAG_KEY},
     };
     use datadog_trace_protobuf::pb;
@@ -202,11 +202,7 @@ mod tests {
             os: "linux".to_string(),
             obfuscation_config: ObfuscationConfig::new().unwrap(),
             proxy_url: None,
-            tags: HashMap::from([
-                ("env".to_string(), "test".to_string()),
-                ("service".to_string(), "my-service".to_string()),
-            ]),
-            function_tags: Some("env:test,service:my-service".to_string()),
+            tags: Tags::from_env_string("env:test,service:my-service"),
         }
     }
 

--- a/crates/datadog-trace-agent/src/trace_processor.rs
+++ b/crates/datadog-trace-agent/src/trace_processor.rs
@@ -189,6 +189,7 @@ mod tests {
             obfuscation_config: ObfuscationConfig::new().unwrap(),
             proxy_url: None,
             tags: HashMap::new(),
+            function_tags: None,
         }
     }
 

--- a/crates/datadog-trace-agent/src/trace_processor.rs
+++ b/crates/datadog-trace-agent/src/trace_processor.rs
@@ -188,6 +188,7 @@ mod tests {
             os: "linux".to_string(),
             obfuscation_config: ObfuscationConfig::new().unwrap(),
             proxy_url: None,
+            tags: HashMap::new(),
         }
     }
 


### PR DESCRIPTION
### What does this PR do?

Adding function tags for traces processed by the the datadog-trace-agent.

Trace metrics don't have these tags yet (are they computed in the tracer for serverless-components?)

### Motivation
This will allow the backend to index traces by these trace tags, enabling trace search queries like `tag_name:value` rather than `@tag_name:value` (the latter would search for span meta attributes instead).

### Additional Notes
This has previously been implemented in the datadog-lambda-extension bottlecap agent and the serverless-init build of the datadog-agent.

### Describe how to test/QA your changes
Added unit tests. Also deployed to a test app to confirm that these function trace tags are being added and result in searchable traces.
