### PR TITLE
feat: update libdatadog rev for removing serverless span type hardcoding

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -811,7 +811,7 @@ dependencies = [
 [[package]]
 name = "datadog-trace-normalization"
 version = "19.1.0"
-source = "git+https://github.com/DataDog/libdatadog/?rev=8a49c7df2d9cbf05118bfd5b85772676f71b34f2#8a49c7df2d9cbf05118bfd5b85772676f71b34f2"
+source = "git+https://github.com/DataDog/libdatadog/?rev=4eb2b8673354f974591c61bab3f7d485b4c119e0#4eb2b8673354f974591c61bab3f7d485b4c119e0"
 dependencies = [
  "anyhow",
  "datadog-trace-protobuf",
@@ -820,7 +820,7 @@ dependencies = [
 [[package]]
 name = "datadog-trace-obfuscation"
 version = "19.1.0"
-source = "git+https://github.com/DataDog/libdatadog/?rev=8a49c7df2d9cbf05118bfd5b85772676f71b34f2#8a49c7df2d9cbf05118bfd5b85772676f71b34f2"
+source = "git+https://github.com/DataDog/libdatadog/?rev=4eb2b8673354f974591c61bab3f7d485b4c119e0#4eb2b8673354f974591c61bab3f7d485b4c119e0"
 dependencies = [
  "anyhow",
  "datadog-trace-protobuf",
@@ -837,7 +837,7 @@ dependencies = [
 [[package]]
 name = "datadog-trace-protobuf"
 version = "19.1.0"
-source = "git+https://github.com/DataDog/libdatadog/?rev=8a49c7df2d9cbf05118bfd5b85772676f71b34f2#8a49c7df2d9cbf05118bfd5b85772676f71b34f2"
+source = "git+https://github.com/DataDog/libdatadog/?rev=4eb2b8673354f974591c61bab3f7d485b4c119e0#4eb2b8673354f974591c61bab3f7d485b4c119e0"
 dependencies = [
  "prost",
  "serde",
@@ -847,7 +847,7 @@ dependencies = [
 [[package]]
 name = "datadog-trace-utils"
 version = "19.1.0"
-source = "git+https://github.com/DataDog/libdatadog/?rev=8a49c7df2d9cbf05118bfd5b85772676f71b34f2#8a49c7df2d9cbf05118bfd5b85772676f71b34f2"
+source = "git+https://github.com/DataDog/libdatadog/?rev=4eb2b8673354f974591c61bab3f7d485b4c119e0#4eb2b8673354f974591c61bab3f7d485b4c119e0"
 dependencies = [
  "anyhow",
  "bytes",
@@ -880,7 +880,7 @@ dependencies = [
 [[package]]
 name = "ddcommon"
 version = "19.1.0"
-source = "git+https://github.com/DataDog/libdatadog/?rev=8a49c7df2d9cbf05118bfd5b85772676f71b34f2#8a49c7df2d9cbf05118bfd5b85772676f71b34f2"
+source = "git+https://github.com/DataDog/libdatadog/?rev=4eb2b8673354f974591c61bab3f7d485b4c119e0#4eb2b8673354f974591c61bab3f7d485b4c119e0"
 dependencies = [
  "anyhow",
  "cc",
@@ -3677,7 +3677,7 @@ dependencies = [
 [[package]]
 name = "tinybytes"
 version = "19.1.0"
-source = "git+https://github.com/DataDog/libdatadog/?rev=8a49c7df2d9cbf05118bfd5b85772676f71b34f2#8a49c7df2d9cbf05118bfd5b85772676f71b34f2"
+source = "git+https://github.com/DataDog/libdatadog/?rev=4eb2b8673354f974591c61bab3f7d485b4c119e0#4eb2b8673354f974591c61bab3f7d485b4c119e0"
 dependencies = [
  "serde",
 ]

--- a/crates/datadog-serverless-compat/Cargo.toml
+++ b/crates/datadog-serverless-compat/Cargo.toml
@@ -9,8 +9,8 @@ description = "Binary to run trace-agent and dogstatsd servers in Serverless env
 log = "0.4"
 env_logger = "0.10.0"
 datadog-trace-agent = { path = "../datadog-trace-agent" }
-datadog-trace-protobuf = { git = "https://github.com/DataDog/libdatadog/", rev = "8a49c7df2d9cbf05118bfd5b85772676f71b34f2" }
-datadog-trace-utils = { git = "https://github.com/DataDog/libdatadog/", rev = "8a49c7df2d9cbf05118bfd5b85772676f71b34f2" }
+datadog-trace-protobuf = { git = "https://github.com/DataDog/libdatadog/", rev = "4eb2b8673354f974591c61bab3f7d485b4c119e0" }
+datadog-trace-utils = { git = "https://github.com/DataDog/libdatadog/", rev = "4eb2b8673354f974591c61bab3f7d485b4c119e0" }
 dogstatsd = { path = "../dogstatsd", default-features = true }
 tokio = { version = "1", features = ["macros", "rt-multi-thread"]}
 tokio-util = { version = "0.7", default-features = false }

--- a/crates/datadog-trace-agent/Cargo.toml
+++ b/crates/datadog-trace-agent/Cargo.toml
@@ -18,15 +18,15 @@ async-trait = "0.1.64"
 tracing = { version = "0.1", default-features = false }
 serde = { version = "1.0.145", features = ["derive"] }
 serde_json = "1.0"
-ddcommon = { git = "https://github.com/DataDog/libdatadog/", rev = "8a49c7df2d9cbf05118bfd5b85772676f71b34f2" }
-datadog-trace-protobuf = { git = "https://github.com/DataDog/libdatadog/", rev = "8a49c7df2d9cbf05118bfd5b85772676f71b34f2" }
-datadog-trace-utils = { git = "https://github.com/DataDog/libdatadog/", rev = "8a49c7df2d9cbf05118bfd5b85772676f71b34f2", features = ["mini_agent"] }
-datadog-trace-normalization = { git = "https://github.com/DataDog/libdatadog/", rev = "8a49c7df2d9cbf05118bfd5b85772676f71b34f2" }
-datadog-trace-obfuscation = { git = "https://github.com/DataDog/libdatadog/", rev = "8a49c7df2d9cbf05118bfd5b85772676f71b34f2" }
+ddcommon = { git = "https://github.com/DataDog/libdatadog/", rev = "4eb2b8673354f974591c61bab3f7d485b4c119e0" }
+datadog-trace-protobuf = { git = "https://github.com/DataDog/libdatadog/", rev = "4eb2b8673354f974591c61bab3f7d485b4c119e0" }
+datadog-trace-utils = { git = "https://github.com/DataDog/libdatadog/", rev = "4eb2b8673354f974591c61bab3f7d485b4c119e0", features = ["mini_agent"] }
+datadog-trace-normalization = { git = "https://github.com/DataDog/libdatadog/", rev = "4eb2b8673354f974591c61bab3f7d485b4c119e0" }
+datadog-trace-obfuscation = { git = "https://github.com/DataDog/libdatadog/", rev = "4eb2b8673354f974591c61bab3f7d485b4c119e0" }
 
 [dev-dependencies]
 rmp-serde = "1.1.1"
 serial_test = "2.0.0"
 duplicate = "0.4.1"
 tempfile = "3.3.0"
-datadog-trace-utils = { git = "https://github.com/DataDog/libdatadog/", rev = "8a49c7df2d9cbf05118bfd5b85772676f71b34f2", features=["test-utils"] }
+datadog-trace-utils = { git = "https://github.com/DataDog/libdatadog/", rev = "4eb2b8673354f974591c61bab3f7d485b4c119e0", features=["test-utils"] }


### PR DESCRIPTION
### What does this PR do?

Update libdatadog rev to point to latest commit on main for removing serverless span type hardcoding in `datadog-trace-utils`.

### Motivation

https://datadoghq.atlassian.net/browse/SVLS-7218

### Additional Notes

https://github.com/DataDog/libdatadog/pull/1149

### Describe how to test/QA your changes

Deployed to Azure Function and confirmed that child spans do not have `span.type: serverless`. It is expected that the root span has `span.type:serverless` since the Azure Function integration in each tracer sets this value.
