### PR TITLE
[SVLS-6337] Shut down trace agent if resource group can't be determined

### DIFF
--- a/crates/datadog-trace-agent/Cargo.toml
+++ b/crates/datadog-trace-agent/Cargo.toml
@@ -11,7 +11,6 @@ bench = false
 anyhow = "1.0"
 hyper = { version = "1.6", features = ["http1", "client", "server"] }
 hyper-util = {version = "0.1", features = ["service"] }
-regex = "1"
 tower = { version = "0.5.2", features = ["util"]  }
 http-body-util = "0.1"
 tokio = { version = "1", features = ["macros", "rt-multi-thread"]}

--- a/crates/datadog-trace-agent/Cargo.toml
+++ b/crates/datadog-trace-agent/Cargo.toml
@@ -11,6 +11,7 @@ bench = false
 anyhow = "1.0"
 hyper = { version = "1.6", features = ["http1", "client", "server"] }
 hyper-util = {version = "0.1", features = ["service"] }
+regex = "1"
 tower = { version = "0.5.2", features = ["util"]  }
 http-body-util = "0.1"
 tokio = { version = "1", features = ["macros", "rt-multi-thread"]}

--- a/crates/datadog-trace-agent/src/env_verifier.rs
+++ b/crates/datadog-trace-agent/src/env_verifier.rs
@@ -375,7 +375,11 @@ mod tests {
     use std::{env, fs, path::Path, time::Duration};
 
     use crate::env_verifier::{
-        ensure_azure_function_environment, ensure_gcp_function_environment, extract_resource_group, get_region_from_gcp_region_string, AzureVerificationClient, AzureVerificationClientWrapper, GCPInstance, GCPMetadata, GCPProject, GoogleMetadataClient, AZURE_FUNCTION_JSON_NAME, AZURE_HOST_JSON_NAME, DD_AZURE_RESOURCE_GROUP, WEBSITE_RESOURCE_GROUP, WEBSITE_OWNER_NAME, get_azure_resource_group
+        ensure_azure_function_environment, ensure_gcp_function_environment, extract_resource_group,
+        get_azure_resource_group, get_region_from_gcp_region_string, AzureVerificationClient,
+        AzureVerificationClientWrapper, GCPInstance, GCPMetadata, GCPProject, GoogleMetadataClient,
+        AZURE_FUNCTION_JSON_NAME, AZURE_HOST_JSON_NAME, DD_AZURE_RESOURCE_GROUP,
+        WEBSITE_OWNER_NAME, WEBSITE_RESOURCE_GROUP,
     };
 
     use super::{EnvVerifier, ServerlessEnvVerifier};
@@ -650,18 +654,26 @@ mod tests {
 
     #[test]
     fn test_extract_azure_resource_group_pattern_match_linux() {
-        let website_owner_name = "00000000-0000-0000-0000-000000000000+test-rg-EastUSwebspace-Linux".to_string();
+        let website_owner_name =
+            "00000000-0000-0000-0000-000000000000+test-rg-EastUSwebspace-Linux".to_string();
         let expected_resource_group = "test-rg".to_string();
 
-        assert_eq!(extract_resource_group(Some(website_owner_name)), Some(expected_resource_group));
+        assert_eq!(
+            extract_resource_group(Some(website_owner_name)),
+            Some(expected_resource_group)
+        );
     }
 
     #[test]
     fn test_extract_azure_resource_group_pattern_match_windows() {
-        let website_owner_name = "00000000-0000-0000-0000-000000000000+test-rg-EastUSwebspace".to_string();
+        let website_owner_name =
+            "00000000-0000-0000-0000-000000000000+test-rg-EastUSwebspace".to_string();
         let expected_resource_group = "test-rg".to_string();
 
-        assert_eq!(extract_resource_group(Some(website_owner_name)), Some(expected_resource_group));
+        assert_eq!(
+            extract_resource_group(Some(website_owner_name)),
+            Some(expected_resource_group)
+        );
     }
 
     #[test]
@@ -683,7 +695,10 @@ mod tests {
     #[test]
     #[serial]
     fn test_get_azure_resource_group_website_owner_name() {
-        env::set_var(WEBSITE_OWNER_NAME, "00000000-0000-0000-0000-000000000000+test-rg-EastUSwebspace-Linux");
+        env::set_var(
+            WEBSITE_OWNER_NAME,
+            "00000000-0000-0000-0000-000000000000+test-rg-EastUSwebspace-Linux",
+        );
         env::remove_var(DD_AZURE_RESOURCE_GROUP);
         env::remove_var(WEBSITE_RESOURCE_GROUP);
         assert_eq!(get_azure_resource_group(), Some("test-rg".to_string()));
@@ -695,7 +710,10 @@ mod tests {
     fn test_get_azure_resource_group_flex_consumption_plan() {
         env::remove_var(WEBSITE_RESOURCE_GROUP);
         env::set_var(DD_AZURE_RESOURCE_GROUP, "test-rg");
-        env::set_var(WEBSITE_OWNER_NAME, "00000000-0000-0000-0000-000000000000+flex-EastUSwebspace-Linux");
+        env::set_var(
+            WEBSITE_OWNER_NAME,
+            "00000000-0000-0000-0000-000000000000+flex-EastUSwebspace-Linux",
+        );
         assert_eq!(get_azure_resource_group(), Some("test-rg".to_string()));
         env::remove_var(WEBSITE_OWNER_NAME);
         env::remove_var(DD_AZURE_RESOURCE_GROUP);
@@ -706,10 +724,12 @@ mod tests {
     fn test_get_azure_resource_group_flex_dd_azure_resource_group_not_set() {
         env::remove_var(WEBSITE_RESOURCE_GROUP);
         env::remove_var(DD_AZURE_RESOURCE_GROUP);
-        env::set_var(WEBSITE_OWNER_NAME, "00000000-0000-0000-0000-000000000000+flex-EastUSwebspace-Linux");
+        env::set_var(
+            WEBSITE_OWNER_NAME,
+            "00000000-0000-0000-0000-000000000000+flex-EastUSwebspace-Linux",
+        );
         assert_eq!(get_azure_resource_group(), None);
         env::remove_var(WEBSITE_OWNER_NAME);
         env::remove_var(DD_AZURE_RESOURCE_GROUP);
     }
-
 }

--- a/crates/datadog-trace-agent/src/env_verifier.rs
+++ b/crates/datadog-trace-agent/src/env_verifier.rs
@@ -642,26 +642,22 @@ mod tests {
     #[test]
     #[serial]
     fn test_is_azure_flex_without_resource_group_true() {
-        env::remove_var(DD_AZURE_RESOURCE_GROUP);
         env::set_var(WEBSITE_SKU, "FlexConsumption");
         assert!(is_azure_flex_without_resource_group());
-        env::remove_var(WEBSITE_SKU);
     }
 
     #[test]
+    #[serial]
     fn test_is_azure_flex_without_resource_group_false_resource_group_set() {
         env::set_var(DD_AZURE_RESOURCE_GROUP, "test-resource-group");
         env::set_var(WEBSITE_SKU, "FlexConsumption");
         assert!(!is_azure_flex_without_resource_group());
-        env::remove_var(WEBSITE_SKU);
-        env::remove_var(DD_AZURE_RESOURCE_GROUP);
     }
 
     #[test]
+    #[serial]
     fn test_is_azure_flex_without_resource_group_false_not_flex() {
-        env::remove_var(DD_AZURE_RESOURCE_GROUP);
         env::set_var(WEBSITE_SKU, "ElasticPremium");
         assert!(!is_azure_flex_without_resource_group());
-        env::remove_var(WEBSITE_SKU);
     }
 }

--- a/crates/datadog-trace-agent/src/env_verifier.rs
+++ b/crates/datadog-trace-agent/src/env_verifier.rs
@@ -5,7 +5,6 @@ use async_trait::async_trait;
 use ddcommon::hyper_migration;
 use http_body_util::BodyExt;
 use hyper::{Method, Request};
-use regex::Regex;
 use serde::{Deserialize, Serialize};
 use std::env;
 use std::fs;
@@ -23,10 +22,9 @@ const AZURE_WINDOWS_FUNCTION_ROOT_PATH_STR: &str = "C:\\home\\site\\wwwroot";
 const AZURE_HOST_JSON_NAME: &str = "host.json";
 const AZURE_FUNCTION_JSON_NAME: &str = "function.json";
 
-// Azure environment variables for resource group detection
+// Azure environment variables for Flex consumption plan detection
 const DD_AZURE_RESOURCE_GROUP: &str = "DD_AZURE_RESOURCE_GROUP";
-const WEBSITE_RESOURCE_GROUP: &str = "WEBSITE_RESOURCE_GROUP";
-const WEBSITE_OWNER_NAME: &str = "WEBSITE_OWNER_NAME";
+const WEBSITE_SKU: &str = "WEBSITE_SKU";
 
 #[derive(Default, Debug, Deserialize, Serialize, Eq, PartialEq)]
 pub struct GCPMetadata {
@@ -248,26 +246,11 @@ async fn get_gcp_metadata_from_body(body: hyper_migration::Body) -> anyhow::Resu
     Ok(gcp_metadata)
 }
 
-/// Determines the Azure resource group using the same logic as libdatadog
-/// Returns None if running in Flex consumption plan without DD_AZURE_RESOURCE_GROUP set
-fn get_azure_resource_group() -> Option<String> {
-    env::var(DD_AZURE_RESOURCE_GROUP)
-        .ok()
-        .or_else(|| env::var(WEBSITE_RESOURCE_GROUP).ok())
-        .or_else(|| extract_resource_group(env::var(WEBSITE_OWNER_NAME).ok()))
-        .filter(|rg| rg != "flex")
-}
-
-/// Extracts resource group from WEBSITE_OWNER_NAME
-/// This uses the exact same regex logic as libdatadog's AzureMetadata::extract_resource_group
-fn extract_resource_group(s: Option<String>) -> Option<String> {
-    #[allow(clippy::unwrap_used)]
-    let re: Regex = Regex::new(r".+\+(.+)-.+webspace(-Linux)?").unwrap();
-
-    s.as_ref().and_then(|text| {
-        re.captures(text)
-            .and_then(|caps| caps.get(1).map(|m| m.as_str().to_string()))
-    })
+/// Checks if we're running in Azure Flex Consumption plan without DD_AZURE_RESOURCE_GROUP set
+/// This would cause billing issues, so we should shut down the trace agent
+fn is_azure_flex_without_resource_group() -> bool {
+    env::var(WEBSITE_SKU).map(|sku| sku == "FlexConsumption").unwrap_or(false)
+        && env::var(DD_AZURE_RESOURCE_GROUP).is_err()
 }
 
 async fn verify_azure_environment_or_exit(os: &str) {
@@ -281,10 +264,12 @@ async fn verify_azure_environment_or_exit(os: &str) {
             process::exit(1);
         }
     }
-    if let None = get_azure_resource_group() {
+    
+    // Check for Azure Flex Consumption plan without DD_AZURE_RESOURCE_GROUP
+    if is_azure_flex_without_resource_group() {
         error!(
-            "Unable to determine Azure resource group. If you are using Azure Functions on the Flex Consumption plan, \
-             please add your resource group name as an environment variable called `DD_AZURE_RESOURCE_GROUP` in Azure App settings."
+            "Azure Flex Consumption plan detected without DD_AZURE_RESOURCE_GROUP set. \
+             Please add your resource group name as an environment variable called `DD_AZURE_RESOURCE_GROUP` in Azure App settings."
         );
         process::exit(1);
     }
@@ -375,11 +360,9 @@ mod tests {
     use std::{env, fs, path::Path, time::Duration};
 
     use crate::env_verifier::{
-        ensure_azure_function_environment, ensure_gcp_function_environment, extract_resource_group,
-        get_azure_resource_group, get_region_from_gcp_region_string, AzureVerificationClient,
+        ensure_azure_function_environment, ensure_gcp_function_environment, get_region_from_gcp_region_string, is_azure_flex_without_resource_group, AzureVerificationClient,
         AzureVerificationClientWrapper, GCPInstance, GCPMetadata, GCPProject, GoogleMetadataClient,
-        AZURE_FUNCTION_JSON_NAME, AZURE_HOST_JSON_NAME, DD_AZURE_RESOURCE_GROUP,
-        WEBSITE_OWNER_NAME, WEBSITE_RESOURCE_GROUP,
+        AZURE_FUNCTION_JSON_NAME, AZURE_HOST_JSON_NAME, WEBSITE_SKU, DD_AZURE_RESOURCE_GROUP,
     };
 
     use super::{EnvVerifier, ServerlessEnvVerifier};
@@ -653,83 +636,28 @@ mod tests {
     }
 
     #[test]
-    fn test_extract_azure_resource_group_pattern_match_linux() {
-        let website_owner_name =
-            "00000000-0000-0000-0000-000000000000+test-rg-EastUSwebspace-Linux".to_string();
-        let expected_resource_group = "test-rg".to_string();
-
-        assert_eq!(
-            extract_resource_group(Some(website_owner_name)),
-            Some(expected_resource_group)
-        );
-    }
-
-    #[test]
-    fn test_extract_azure_resource_group_pattern_match_windows() {
-        let website_owner_name =
-            "00000000-0000-0000-0000-000000000000+test-rg-EastUSwebspace".to_string();
-        let expected_resource_group = "test-rg".to_string();
-
-        assert_eq!(
-            extract_resource_group(Some(website_owner_name)),
-            Some(expected_resource_group)
-        );
-    }
-
-    #[test]
-    fn test_extract_azure_resource_group_no_pattern_match() {
-        let website_owner_name = "foo".to_string();
-
-        assert_eq!(extract_resource_group(Some(website_owner_name)), None);
-    }
-
-    #[test]
     #[serial]
-    fn test_get_azure_resource_group_website_resource_group() {
-        env::set_var(WEBSITE_RESOURCE_GROUP, "test-rg");
+    fn test_is_azure_flex_without_resource_group_true() {
         env::remove_var(DD_AZURE_RESOURCE_GROUP);
-        assert_eq!(get_azure_resource_group(), Some("test-rg".to_string()));
-        env::remove_var(WEBSITE_RESOURCE_GROUP);
+        env::set_var(WEBSITE_SKU, "FlexConsumption");
+        assert!(is_azure_flex_without_resource_group());
+        env::remove_var(WEBSITE_SKU);
     }
-
+    
     #[test]
-    #[serial]
-    fn test_get_azure_resource_group_website_owner_name() {
-        env::set_var(
-            WEBSITE_OWNER_NAME,
-            "00000000-0000-0000-0000-000000000000+test-rg-EastUSwebspace-Linux",
-        );
-        env::remove_var(DD_AZURE_RESOURCE_GROUP);
-        env::remove_var(WEBSITE_RESOURCE_GROUP);
-        assert_eq!(get_azure_resource_group(), Some("test-rg".to_string()));
-        env::remove_var(WEBSITE_OWNER_NAME);
-    }
-
-    #[test]
-    #[serial]
-    fn test_get_azure_resource_group_flex_consumption_plan() {
-        env::remove_var(WEBSITE_RESOURCE_GROUP);
-        env::set_var(DD_AZURE_RESOURCE_GROUP, "test-rg");
-        env::set_var(
-            WEBSITE_OWNER_NAME,
-            "00000000-0000-0000-0000-000000000000+flex-EastUSwebspace-Linux",
-        );
-        assert_eq!(get_azure_resource_group(), Some("test-rg".to_string()));
-        env::remove_var(WEBSITE_OWNER_NAME);
+    fn test_is_azure_flex_without_resource_group_false_resource_group_set() {
+        env::set_var(DD_AZURE_RESOURCE_GROUP, "test-resource-group");
+        env::set_var(WEBSITE_SKU, "FlexConsumption");
+        assert!(!is_azure_flex_without_resource_group());
+        env::remove_var(WEBSITE_SKU);
         env::remove_var(DD_AZURE_RESOURCE_GROUP);
     }
 
     #[test]
-    #[serial]
-    fn test_get_azure_resource_group_flex_dd_azure_resource_group_not_set() {
-        env::remove_var(WEBSITE_RESOURCE_GROUP);
+    fn test_is_azure_flex_without_resource_group_false_not_flex() {
         env::remove_var(DD_AZURE_RESOURCE_GROUP);
-        env::set_var(
-            WEBSITE_OWNER_NAME,
-            "00000000-0000-0000-0000-000000000000+flex-EastUSwebspace-Linux",
-        );
-        assert_eq!(get_azure_resource_group(), None);
-        env::remove_var(WEBSITE_OWNER_NAME);
-        env::remove_var(DD_AZURE_RESOURCE_GROUP);
+        env::set_var(WEBSITE_SKU, "ElasticPremium");
+        assert!(!is_azure_flex_without_resource_group());
+        env::remove_var(WEBSITE_SKU);
     }
 }

--- a/crates/datadog-trace-agent/src/env_verifier.rs
+++ b/crates/datadog-trace-agent/src/env_verifier.rs
@@ -249,7 +249,9 @@ async fn get_gcp_metadata_from_body(body: hyper_migration::Body) -> anyhow::Resu
 /// Checks if we're running in Azure Flex Consumption plan without DD_AZURE_RESOURCE_GROUP set
 /// This would cause billing issues, so we should shut down the trace agent
 fn is_azure_flex_without_resource_group() -> bool {
-    env::var(WEBSITE_SKU).map(|sku| sku == "FlexConsumption").unwrap_or(false)
+    env::var(WEBSITE_SKU)
+        .map(|sku| sku == "FlexConsumption")
+        .unwrap_or(false)
         && env::var(DD_AZURE_RESOURCE_GROUP).is_err()
 }
 
@@ -264,7 +266,7 @@ async fn verify_azure_environment_or_exit(os: &str) {
             process::exit(1);
         }
     }
-    
+
     // Check for Azure Flex Consumption plan without DD_AZURE_RESOURCE_GROUP
     if is_azure_flex_without_resource_group() {
         error!(
@@ -360,9 +362,11 @@ mod tests {
     use std::{env, fs, path::Path, time::Duration};
 
     use crate::env_verifier::{
-        ensure_azure_function_environment, ensure_gcp_function_environment, get_region_from_gcp_region_string, is_azure_flex_without_resource_group, AzureVerificationClient,
-        AzureVerificationClientWrapper, GCPInstance, GCPMetadata, GCPProject, GoogleMetadataClient,
-        AZURE_FUNCTION_JSON_NAME, AZURE_HOST_JSON_NAME, WEBSITE_SKU, DD_AZURE_RESOURCE_GROUP,
+        ensure_azure_function_environment, ensure_gcp_function_environment,
+        get_region_from_gcp_region_string, is_azure_flex_without_resource_group,
+        AzureVerificationClient, AzureVerificationClientWrapper, GCPInstance, GCPMetadata,
+        GCPProject, GoogleMetadataClient, AZURE_FUNCTION_JSON_NAME, AZURE_HOST_JSON_NAME,
+        DD_AZURE_RESOURCE_GROUP, WEBSITE_SKU,
     };
 
     use super::{EnvVerifier, ServerlessEnvVerifier};
@@ -643,7 +647,7 @@ mod tests {
         assert!(is_azure_flex_without_resource_group());
         env::remove_var(WEBSITE_SKU);
     }
-    
+
     #[test]
     fn test_is_azure_flex_without_resource_group_false_resource_group_set() {
         env::set_var(DD_AZURE_RESOURCE_GROUP, "test-resource-group");


### PR DESCRIPTION
### What does this PR do?
Adds a check to see if we are in an Azure function that is on the flex consumption plan and doesn't have the `DD_AZURE_RESOURCE_GROUP` env var set. If so, shut down the trace agent.

- We updated the `libdatadog` [Azure metadata detection logic](https://github.com/DataDog/libdatadog/pull/1241) to check for the env var similarly
- We also plan to update the serverless-compat layers to check for these env vars too for defense in depth.

### Motivation
- Currently the `aas.resource.group` span attribute for functions on flex consumption plans is set incorrectly in Datadog - they're all set to "flex"
  - This is important to fix because `aas.resource.id` is built using `aas.resource.group`, and the resource id is used in billing, which needs to be accurate
  - We had to figure out what to do if a customer who is using Datadog to monitor their Azure function on a flex consumption plan doesn't set the `DD_AZURE_RESOURCE_GROUP` env var. Rather than handling that in `libdatadog`, we decided to do it at a higher level in the trace agent to inform the customer of the error while shutting down the trace agent gracefully and preventing any traces from being sent to Datadog

[Jira Ticket](https://datadoghq.atlassian.net/browse/SVLS-6337?atlOrigin=eyJpIjoiNzhhNTkwOWFmODFhNGZjZmJhZDc1OGE2ZjJkOTg0NjYiLCJwIjoiaiJ9)

### Describe how to test/QA your changes

1. Update the commit hash in [datadog-trace-agent/Cargo.toml
](https://github.com/DataDog/serverless-components/blob/main/crates/datadog-trace-agent/Cargo.toml) everywhere that `libdatadog` is used to the most recent commit hash of the PR in [libdatadog](https://github.com/DataDog/libdatadog/pull/1241) (currently `d1b35ef21fff3c4588073504905081c8923bbc4b`)
2. Follow the instructions in the [Serverless Compatability Layer docs](https://datadoghq.atlassian.net/wiki/spaces/SLS/pages/2977497119/Serverless+Compatibility+Layer) to build the Rust binary
3. Deploy an Azure function on flex consumption plan using [the terraform tool](https://github.com/DataDog/serverless-init-self-monitoring/tree/main/old-self-monitoring/azure/functions), setting `use_serverless_compat_local_path` to true and making sure the built binary is in your `python` folder
4. Hit an endpoint in your function or wait a minute for the invoker to invoke your function and check the Datadog traces for your function. Without the `DD_AZURE_RESOURCE_GROUP` env var, you should see no traces. Check the logs in Azure Portal - you should see an error log with the message `"ERROR: Resource group not found. If you are using Azure Functions on Flex Consumption plan, please add your resource group name as an environment variable called DD_AZURE_RESOURCE_GROUP in Azure app settings."`
6. Go to Settings > Environment Variables in the Azure Portal for your function and add `DD_AZURE_RESOURCE_GROUP` as an environment variable with your resource group. Repeat step 4, you should see the correct resource group in the `resource.group` span attribute!

Expected error without `DD_AZURE_RESOURCE_GROUP`, no traces sent to DD:
<img width="1014" height="137" alt="image" src="https://github.com/user-attachments/assets/7b6f495b-4715-46d9-b354-10876f70bd0a" />

With `DD_AZURE_RESOURCE_GROUP` - traces sent to DD with the correct resource group/id.
<img width="868" height="659" alt="Screenshot 2025-09-25 at 11 39 44 AM" src="https://github.com/user-attachments/assets/982b9cfa-ccc6-431e-8dc3-6c695017c994" />
