### PR TITLE
ci: add Linux ARM64 support to build and release workflows

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,5 +1,8 @@
 [target.x86_64-unknown-linux-musl]
 linker = "x86_64-linux-musl-gcc"
 
+[target.aarch64-unknown-linux-musl]
+linker = "aarch64-linux-musl-gcc"
+
 [target.x86_64-pc-windows-gnu]
 linker = "x86_64-w64-mingw32-gcc"

--- a/.github/workflows/build-datadog-serverless-compat.yml
+++ b/.github/workflows/build-datadog-serverless-compat.yml
@@ -23,7 +23,6 @@ jobs:
       - uses: mozilla-actions/sccache-action@65101d47ea8028ed0c98a1cdea8dd9182e9b5133 #v0.0.8
   build-datadog-serverless-compat:
     name: Build Datadog Serverless Compat
-    if: ${{ inputs.runner != 'ubuntu-24.04-arm' }}
     needs: setup
     runs-on: ${{ inputs.runner }}
     steps:
@@ -42,6 +41,18 @@ jobs:
         with:
           name: linux-amd64
           path: target/x86_64-unknown-linux-musl/release/datadog-serverless-compat
+          retention-days: 3
+      - if: ${{ inputs.runner == 'ubuntu-24.04-arm' }}
+        shell: bash
+        run: |
+          sudo apt-get update
+          rustup target add aarch64-unknown-linux-musl && sudo apt-get install -y musl-tools
+          cargo build --release -p datadog-serverless-compat --target aarch64-unknown-linux-musl
+      - if: ${{ inputs.runner == 'ubuntu-24.04-arm' }}
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # 4.6.2
+        with:
+          name: linux-arm64
+          path: target/aarch64-unknown-linux-musl/release/datadog-serverless-compat
           retention-days: 3
       - if: ${{ inputs.runner == 'windows-2022' }}
         shell: bash

--- a/.github/workflows/release-datadog-serverless-compat-per-platform.yml
+++ b/.github/workflows/release-datadog-serverless-compat-per-platform.yml
@@ -1,0 +1,51 @@
+name: Release Datadog Serverless Compat (Per Platform)
+
+on: workflow_dispatch
+
+permissions: {}
+
+jobs:
+  build:
+    strategy:
+      fail-fast: false
+      matrix:
+        runner: [ubuntu-24.04, ubuntu-24.04-arm, windows-2022]
+    uses: ./.github/workflows/build-datadog-serverless-compat.yml
+    with:
+      runner: ${{matrix.runner}}
+  release:
+    runs-on: ubuntu-24.04
+    needs: build
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # 4.3.0
+        with:
+          name: linux-amd64
+          path: target/linux-amd64
+      - run: |
+          chmod +x target/linux-amd64/datadog-serverless-compat
+          upx target/linux-amd64/datadog-serverless-compat --lzma
+      - run: zip -j datadog-serverless-compat-linux-amd64.zip target/linux-amd64/datadog-serverless-compat
+      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # 4.3.0
+        with:
+          name: linux-arm64
+          path: target/linux-arm64
+      - run: |
+          chmod +x target/linux-arm64/datadog-serverless-compat
+          upx target/linux-arm64/datadog-serverless-compat --lzma
+      - run: zip -j datadog-serverless-compat-linux-arm64.zip target/linux-arm64/datadog-serverless-compat
+      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # 4.3.0
+        with:
+          name: windows-amd64
+          path: target/windows-amd64
+      - run: upx target/windows-amd64/datadog-serverless-compat.exe --lzma
+      - run: zip -j datadog-serverless-compat-windows-amd64.zip target/windows-amd64/datadog-serverless-compat.exe
+      - uses: softprops/action-gh-release@da05d552573ad5aba039eaac05058a918a7bf631 # v2.2.2
+        with:
+          draft: true
+          generate_release_notes: true
+          files: |
+            datadog-serverless-compat-linux-amd64.zip
+            datadog-serverless-compat-linux-arm64.zip
+            datadog-serverless-compat-windows-amd64.zip

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,9 @@ resolver = "2"
 members = [
   "crates/*",
 ]
+exclude = [
+  "crates/.claude",
+]
 
 [workspace.package]
 edition = "2024"


### PR DESCRIPTION
https://datadoghq.atlassian.net/browse/SVLS-8574

## What does this PR do?

We add Linux ARM64 (`aarch64-unknown-linux-musl`) as a supported build and release target for `datadog-serverless-compat`, alongside the existing Linux AMD64 and Windows AMD64 targets.

We also introduced a platform-specific serverless-compatible packaging solution so the final user deployment includes only the relevant binary.

## Changes

**Add support for `linux-arm64` release**

**Introduce a new Github action**
- `Release Datadog Serverless Compat (Per Platform)` to create the platform specific packages while keeping the existing single package solution.

**Update `Cargo.toml`** 
- Prevent the workspace glob `crates/*` from resolving the `.claude` tooling directory as a Cargo member

## Testing

Built and released both targets locally:
- `linux-arm64`: 5.8 MB raw → 2.0 MB after `upx --lzma` (33% of original)
- `linux-amd64`: 7.8 MB raw → 2.3 MB after `upx --lzma` (29% of original)

Verified the ARM64 binary is a valid `ELF 64-bit LSB executable, ARM aarch64, statically linked`.