### PR TITLE
feat: add DD_ORG_UUID to datadog-agent-config crate

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,29 @@
+# Copilot Code Review Instructions
+
+## Security — PII and Secrets
+
+Flag any logging statements (`log::info!`, `log::debug!`, `log::warn!`, `log::error!`,
+`tracing::info!`, `tracing::debug!`, `tracing::warn!`, `tracing::error!`, or unqualified
+`info!`, `debug!`, `warn!`, `error!` macros (e.g., via `use tracing::{info, debug, warn, error}`))
+that may log:
+- HTTP request/response headers (Authorization, Cookie, X-API-Key, or similar)
+- HTTP request/response bodies or raw payloads
+- Any PII fields (e.g., email, name, user_id, ip_address, phone, ssn, date_of_birth)
+- API keys, tokens, secrets, or credentials
+- Structs or types that contain any of the above fields
+- `SendData` values or any variable that contains a `SendData` object (e.g.,
+  `traces_with_tags` or similar variables built via `.with_api_key(...).build()`),
+  since these embed the Datadog API key
+
+Suggest redacting or omitting the sensitive field rather than logging it.
+
+## Security — Unsafe Rust
+
+Flag new `unsafe` blocks and explain what invariant the author must uphold to make the
+block safe. If there is a safe alternative, suggest it.
+
+## Security — Error Handling
+
+Flag cases where errors are silently swallowed (empty `catch`, `.ok()` without
+handling, `let _ = result`) or where operations like `.unwrap()`/`.expect()` may panic,
+in code paths that handle external input or network responses.

--- a/.github/workflows/build-datadog-serverless-compat.yml
+++ b/.github/workflows/build-datadog-serverless-compat.yml
@@ -63,3 +63,25 @@ jobs:
           name: windows-amd64
           path: target/release/datadog-serverless-compat.exe
           retention-days: 3
+      - if: ${{ inputs.runner == 'windows-2022' }}
+        shell: bash
+        run: |
+          rustup target add i686-pc-windows-msvc
+          cargo build --release -p datadog-serverless-compat \
+            --target i686-pc-windows-msvc \
+            --features windows-pipes
+      - if: ${{ inputs.runner == 'windows-2022' }}
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # 4.6.2
+        with:
+          name: windows-ia32
+          path: target/i686-pc-windows-msvc/release/datadog-serverless-compat.exe
+          retention-days: 3
+      - if: ${{ inputs.runner == 'macos-14' }}
+        shell: bash
+        run: cargo build --release -p datadog-serverless-compat
+      - if: ${{ inputs.runner == 'macos-14' }}
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # 4.6.2
+        with:
+          name: darwin-arm64
+          path: target/release/datadog-serverless-compat
+          retention-days: 3

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -24,7 +24,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        runner: [ubuntu-24.04, ubuntu-24.04-arm, windows-2022]
+        runner: [ubuntu-24.04, ubuntu-24.04-arm, windows-2022, macos-14]
     uses: ./.github/workflows/build-datadog-serverless-compat.yml
     with:
       runner: ${{ matrix.runner }}
@@ -56,6 +56,16 @@ jobs:
           name: windows-amd64
           path: target/windows-amd64
       - run: upx target/windows-amd64/datadog-serverless-compat.exe --lzma
+      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # 4.3.0
+        with:
+          name: windows-ia32
+          path: target/windows-ia32
+      - run: upx target/windows-ia32/datadog-serverless-compat.exe --lzma
+      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # 4.3.0
+        with:
+          name: darwin-arm64
+          path: target/darwin-arm64
+      - run: chmod +x target/darwin-arm64/datadog-serverless-compat
       - name: Determine version
         id: determine-version
         env:
@@ -85,6 +95,14 @@ jobs:
           mkdir -p npm/datadog-serverless-compat-win32-x64/bin
           cp target/windows-amd64/datadog-serverless-compat.exe npm/datadog-serverless-compat-win32-x64/bin/
           npm --prefix npm/datadog-serverless-compat-win32-x64 pkg set version="$VERSION"
+
+          mkdir -p npm/datadog-serverless-compat-win32-ia32/bin
+          cp target/windows-ia32/datadog-serverless-compat.exe npm/datadog-serverless-compat-win32-ia32/bin/
+          npm --prefix npm/datadog-serverless-compat-win32-ia32 pkg set version="$VERSION"
+
+          mkdir -p npm/datadog-serverless-compat-darwin-arm64/bin
+          cp target/darwin-arm64/datadog-serverless-compat npm/datadog-serverless-compat-darwin-arm64/bin/
+          npm --prefix npm/datadog-serverless-compat-darwin-arm64 pkg set version="$VERSION"
       - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # 4.6.2
         with:
           name: npm-packages
@@ -105,8 +123,13 @@ jobs:
         with:
           node-version: "22.x"
           registry-url: 'https://registry.npmjs.org'
+      - run: npm config set //registry.npmjs.org/:_authToken=$NPM_PUBLISH_TOKEN
+        env:
+          NPM_PUBLISH_TOKEN: ${{ secrets.NPM_PUBLISH_TOKEN }}
       - name: Publish npm packages
         run: |
           npm publish ./npm/datadog-serverless-compat-linux-x64 --provenance --access public
           npm publish ./npm/datadog-serverless-compat-linux-arm64 --provenance --access public
           npm publish ./npm/datadog-serverless-compat-win32-x64 --provenance --access public
+          npm publish ./npm/datadog-serverless-compat-win32-ia32 --provenance --access public
+          npm publish ./npm/datadog-serverless-compat-darwin-arm64 --provenance --access public

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /target
 /.idea
+/.worktrees
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -213,6 +213,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "borrow-or-share"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc0b364ead1874514c8c2855ab558056ebfeb775653e7ae45ff72f28f8f3166c"
+
+[[package]]
 name = "bumpalo"
 version = "3.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -442,7 +448,7 @@ dependencies = [
  "dogstatsd",
  "figment",
  "libdd-trace-obfuscation",
- "libdd-trace-utils 1.0.0",
+ "libdd-trace-utils 3.0.0",
  "log",
  "serde",
  "serde-aux",
@@ -515,7 +521,7 @@ dependencies = [
  "datadog-fips",
  "datadog-trace-agent",
  "dogstatsd",
- "libdd-trace-utils 1.0.0",
+ "libdd-trace-utils 3.0.0",
  "reqwest",
  "tokio",
  "tokio-util",
@@ -537,10 +543,10 @@ dependencies = [
  "hyper",
  "hyper-http-proxy",
  "hyper-util",
- "libdd-common 1.1.0",
+ "libdd-common 3.0.1",
  "libdd-trace-obfuscation",
- "libdd-trace-protobuf 1.0.0",
- "libdd-trace-utils 1.0.0",
+ "libdd-trace-protobuf 3.0.0",
+ "libdd-trace-utils 3.0.0",
  "reqwest",
  "rmp-serde",
  "serde",
@@ -742,6 +748,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b09cf3155332e944990140d967ff5eceb70df778b34f77d8075db46e4704e6d8"
 dependencies = [
  "num-traits",
+]
+
+[[package]]
+name = "fluent-uri"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc74ac4d8359ae70623506d512209619e5cf8f347124910440dbc221714b328e"
+dependencies = [
+ "borrow-or-share",
+ "ref-cast",
+ "serde",
 ]
 
 [[package]]
@@ -1394,39 +1411,6 @@ checksum = "b5b646652bf6661599e1da8901b3b9522896f01e736bad5f723fe7a3a27f899d"
 
 [[package]]
 name = "libdd-common"
-version = "1.1.0"
-source = "git+https://github.com/DataDog/libdatadog?rev=d52ee90209cb12a28bdda0114535c1a985a29d95#d52ee90209cb12a28bdda0114535c1a985a29d95"
-dependencies = [
- "anyhow",
- "cc",
- "const_format",
- "futures",
- "futures-core",
- "futures-util",
- "hex",
- "http",
- "http-body",
- "http-body-util",
- "hyper",
- "hyper-rustls",
- "hyper-util",
- "libc",
- "nix",
- "pin-project",
- "regex",
- "rustls",
- "rustls-native-certs",
- "serde",
- "static_assertions",
- "thiserror 1.0.69",
- "tokio",
- "tokio-rustls",
- "tower-service",
- "windows-sys 0.52.0",
-]
-
-[[package]]
-name = "libdd-common"
 version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e5593b91f61eee38cddc9fdcbc99c9fad697b5d925e226bd500d86b4295380b"
@@ -1452,6 +1436,40 @@ dependencies = [
  "static_assertions",
  "thiserror 1.0.69",
  "tokio",
+ "tower-service",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "libdd-common"
+version = "3.0.1"
+source = "git+https://github.com/DataDog/libdatadog?rev=8c88979985154d6d97c0fc2ca9039682981eacad#8c88979985154d6d97c0fc2ca9039682981eacad"
+dependencies = [
+ "anyhow",
+ "bytes",
+ "cc",
+ "const_format",
+ "futures",
+ "futures-core",
+ "futures-util",
+ "hex",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-rustls",
+ "hyper-util",
+ "libc",
+ "nix",
+ "pin-project",
+ "regex",
+ "rustls",
+ "rustls-native-certs",
+ "serde",
+ "static_assertions",
+ "thiserror 1.0.69",
+ "tokio",
+ "tokio-rustls",
  "tower-service",
  "windows-sys 0.52.0",
 ]
@@ -1546,18 +1564,9 @@ dependencies = [
 [[package]]
 name = "libdd-tinybytes"
 version = "1.1.0"
-source = "git+https://github.com/DataDog/libdatadog?rev=d52ee90209cb12a28bdda0114535c1a985a29d95#d52ee90209cb12a28bdda0114535c1a985a29d95"
+source = "git+https://github.com/DataDog/libdatadog?rev=8c88979985154d6d97c0fc2ca9039682981eacad#8c88979985154d6d97c0fc2ca9039682981eacad"
 dependencies = [
  "serde",
-]
-
-[[package]]
-name = "libdd-trace-normalization"
-version = "1.0.0"
-source = "git+https://github.com/DataDog/libdatadog?rev=d52ee90209cb12a28bdda0114535c1a985a29d95#d52ee90209cb12a28bdda0114535c1a985a29d95"
-dependencies = [
- "anyhow",
- "libdd-trace-protobuf 1.0.0",
 ]
 
 [[package]]
@@ -1571,26 +1580,36 @@ dependencies = [
 ]
 
 [[package]]
-name = "libdd-trace-obfuscation"
-version = "1.0.0"
-source = "git+https://github.com/DataDog/libdatadog?rev=d52ee90209cb12a28bdda0114535c1a985a29d95#d52ee90209cb12a28bdda0114535c1a985a29d95"
+name = "libdd-trace-normalization"
+version = "1.0.3"
+source = "git+https://github.com/DataDog/libdatadog?rev=8c88979985154d6d97c0fc2ca9039682981eacad#8c88979985154d6d97c0fc2ca9039682981eacad"
 dependencies = [
  "anyhow",
- "libdd-common 1.1.0",
- "libdd-trace-protobuf 1.0.0",
- "libdd-trace-utils 1.0.0",
+ "libdd-trace-protobuf 3.0.0",
+]
+
+[[package]]
+name = "libdd-trace-obfuscation"
+version = "1.0.1"
+source = "git+https://github.com/DataDog/libdatadog?rev=8c88979985154d6d97c0fc2ca9039682981eacad#8c88979985154d6d97c0fc2ca9039682981eacad"
+dependencies = [
+ "anyhow",
+ "fluent-uri",
+ "libdd-common 3.0.1",
+ "libdd-trace-protobuf 3.0.0",
+ "libdd-trace-utils 3.0.0",
  "log",
  "percent-encoding",
  "regex",
  "serde",
  "serde_json",
- "url",
 ]
 
 [[package]]
 name = "libdd-trace-protobuf"
-version = "1.0.0"
-source = "git+https://github.com/DataDog/libdatadog?rev=d52ee90209cb12a28bdda0114535c1a985a29d95#d52ee90209cb12a28bdda0114535c1a985a29d95"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d0a54921e03174f3ff7ad8506ff9e13637e546ef0b1f369ae463eacebda8e88"
 dependencies = [
  "prost 0.14.3",
  "serde",
@@ -1599,9 +1618,8 @@ dependencies = [
 
 [[package]]
 name = "libdd-trace-protobuf"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d0a54921e03174f3ff7ad8506ff9e13637e546ef0b1f369ae463eacebda8e88"
+version = "3.0.0"
+source = "git+https://github.com/DataDog/libdatadog?rev=8c88979985154d6d97c0fc2ca9039682981eacad#8c88979985154d6d97c0fc2ca9039682981eacad"
 dependencies = [
  "prost 0.14.3",
  "serde",
@@ -1618,39 +1636,6 @@ dependencies = [
  "libdd-ddsketch",
  "libdd-trace-protobuf 2.0.0",
  "libdd-trace-utils 2.0.2",
-]
-
-[[package]]
-name = "libdd-trace-utils"
-version = "1.0.0"
-source = "git+https://github.com/DataDog/libdatadog?rev=d52ee90209cb12a28bdda0114535c1a985a29d95#d52ee90209cb12a28bdda0114535c1a985a29d95"
-dependencies = [
- "anyhow",
- "bytes",
- "cargo-platform",
- "cargo_metadata",
- "flate2",
- "futures",
- "http",
- "http-body-util",
- "httpmock",
- "hyper",
- "indexmap",
- "libdd-common 1.1.0",
- "libdd-tinybytes 1.1.0 (git+https://github.com/DataDog/libdatadog?rev=d52ee90209cb12a28bdda0114535c1a985a29d95)",
- "libdd-trace-normalization 1.0.0",
- "libdd-trace-protobuf 1.0.0",
- "prost 0.14.3",
- "rand 0.8.5",
- "rmp",
- "rmp-serde",
- "rmpv",
- "serde",
- "serde_json",
- "tokio",
- "tracing",
- "urlencoding",
- "zstd",
 ]
 
 [[package]]
@@ -1679,6 +1664,40 @@ dependencies = [
  "serde_json",
  "tokio",
  "tracing",
+]
+
+[[package]]
+name = "libdd-trace-utils"
+version = "3.0.0"
+source = "git+https://github.com/DataDog/libdatadog?rev=8c88979985154d6d97c0fc2ca9039682981eacad#8c88979985154d6d97c0fc2ca9039682981eacad"
+dependencies = [
+ "anyhow",
+ "bytes",
+ "cargo-platform",
+ "cargo_metadata",
+ "flate2",
+ "futures",
+ "http",
+ "http-body",
+ "http-body-util",
+ "httpmock",
+ "hyper",
+ "indexmap",
+ "libdd-common 3.0.1",
+ "libdd-tinybytes 1.1.0 (git+https://github.com/DataDog/libdatadog?rev=8c88979985154d6d97c0fc2ca9039682981eacad)",
+ "libdd-trace-normalization 1.0.3",
+ "libdd-trace-protobuf 3.0.0",
+ "prost 0.14.3",
+ "rand 0.8.5",
+ "rmp",
+ "rmp-serde",
+ "rmpv",
+ "serde",
+ "serde_json",
+ "tokio",
+ "tracing",
+ "urlencoding",
+ "zstd",
 ]
 
 [[package]]
@@ -2416,6 +2435,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "ref-cast"
+version = "1.0.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f354300ae66f76f1c85c5f84693f0ce81d747e2c3f21a45fef496d89c960bf7d"
+dependencies = [
+ "ref-cast-impl",
+]
+
+[[package]]
+name = "ref-cast-impl"
+version = "1.0.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7186006dcb21920990093f30e3dea63b7d6e977bf1256be20c3563a5db070da"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "regex"
 version = "1.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2764,6 +2803,7 @@ version = "1.0.149"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "83fc039473c5595ace860d8c4fafa220ff474b3fc6bfdb4293327f1a37e94d86"
 dependencies = [
+ "indexmap",
  "itoa",
  "memchr",
  "serde",

--- a/LICENSE-3rdparty.csv
+++ b/LICENSE-3rdparty.csv
@@ -20,6 +20,7 @@ bit-set,https://github.com/contain-rs/bit-set,Apache-2.0 OR MIT,Alexis Beingessn
 bit-vec,https://github.com/contain-rs/bit-vec,Apache-2.0 OR MIT,Alexis Beingessner <a.beingessner@gmail.com>
 bitflags,https://github.com/bitflags/bitflags,MIT OR Apache-2.0,The Rust Project Developers
 block-buffer,https://github.com/RustCrypto/utils,MIT OR Apache-2.0,RustCrypto Developers
+borrow-or-share,https://github.com/yescallop/borrow-or-share,MIT-0,Scallop Ye <yescallop@gmail.com>
 bumpalo,https://github.com/fitzgen/bumpalo,MIT OR Apache-2.0,Nick Fitzgerald <fitzgen@gmail.com>
 bytemuck,https://github.com/Lokathor/bytemuck,Zlib OR Apache-2.0 OR MIT,Lokathor <zefria@gmail.com>
 byteorder,https://github.com/BurntSushi/byteorder,Unlicense OR MIT,Andrew Gallant <jamslam@gmail.com>
@@ -61,6 +62,7 @@ find-msvc-tools,https://github.com/rust-lang/cc-rs,MIT OR Apache-2.0,The find-ms
 fixedbitset,https://github.com/petgraph/fixedbitset,MIT OR Apache-2.0,bluss
 flate2,https://github.com/rust-lang/flate2-rs,MIT OR Apache-2.0,"Alex Crichton <alex@alexcrichton.com>, Josh Triplett <josh@joshtriplett.org>"
 float-cmp,https://github.com/mikedilger/float-cmp,MIT,Mike Dilger <mike@mikedilger.com>
+fluent-uri,https://github.com/yescallop/fluent-uri-rs,MIT,Scallop Ye <yescallop@gmail.com>
 fnv,https://github.com/servo/rust-fnv,Apache-2.0  OR  MIT,Alex Crichton <alex@alexcrichton.com>
 foldhash,https://github.com/orlp/foldhash,Zlib,Orson Peters <orsonpeters@gmail.com>
 form_urlencoded,https://github.com/servo/rust-url,MIT OR Apache-2.0,The rust-url developers
@@ -188,6 +190,8 @@ rand_chacha,https://github.com/rust-random/rand,MIT OR Apache-2.0,"The Rand Proj
 rand_core,https://github.com/rust-random/rand,MIT OR Apache-2.0,"The Rand Project Developers, The Rust Project Developers"
 rand_xorshift,https://github.com/rust-random/rngs,MIT OR Apache-2.0,"The Rand Project Developers, The Rust Project Developers"
 redox_syscall,https://gitlab.redox-os.org/redox-os/syscall,MIT,Jeremy Soller <jackpot51@gmail.com>
+ref-cast,https://github.com/dtolnay/ref-cast,MIT OR Apache-2.0,David Tolnay <dtolnay@gmail.com>
+ref-cast-impl,https://github.com/dtolnay/ref-cast,MIT OR Apache-2.0,David Tolnay <dtolnay@gmail.com>
 regex,https://github.com/rust-lang/regex,MIT OR Apache-2.0,"The Rust Project Developers, Andrew Gallant <jamslam@gmail.com>"
 regex-automata,https://github.com/rust-lang/regex,MIT OR Apache-2.0,"The Rust Project Developers, Andrew Gallant <jamslam@gmail.com>"
 regex-syntax,https://github.com/rust-lang/regex,MIT OR Apache-2.0,"The Rust Project Developers, Andrew Gallant <jamslam@gmail.com>"

--- a/crates/datadog-agent-config/Cargo.toml
+++ b/crates/datadog-agent-config/Cargo.toml
@@ -9,8 +9,8 @@ path = "mod.rs"
 
 [dependencies]
 figment = { version = "0.10", default-features = false, features = ["yaml", "env"] }
-libdd-trace-obfuscation = { git = "https://github.com/DataDog/libdatadog", rev = "d52ee90209cb12a28bdda0114535c1a985a29d95" }
-libdd-trace-utils = { git = "https://github.com/DataDog/libdatadog", rev = "d52ee90209cb12a28bdda0114535c1a985a29d95" }
+libdd-trace-obfuscation = { git = "https://github.com/DataDog/libdatadog", rev = "8c88979985154d6d97c0fc2ca9039682981eacad" }
+libdd-trace-utils = { git = "https://github.com/DataDog/libdatadog", rev = "8c88979985154d6d97c0fc2ca9039682981eacad" }
 log = { version = "0.4", default-features = false }
 serde = { version = "1.0", default-features = false, features = ["derive"] }
 serde-aux = { version = "4.7", default-features = false }

--- a/crates/datadog-agent-config/env.rs
+++ b/crates/datadog-agent-config/env.rs
@@ -478,6 +478,11 @@ pub struct EnvConfig {
     /// The delay between two samples of the API Security schema collection, in seconds.
     #[serde(deserialize_with = "deserialize_optional_duration_from_seconds")]
     pub api_security_sample_delay: Option<Duration>,
+    /// @env `DD_ORG_UUID`
+    ///
+    /// The Datadog organization UUID. When set, delegated AWS auth is auto-enabled.
+    #[serde(deserialize_with = "deserialize_optional_string")]
+    pub org_uuid: Option<String>,
 }
 
 #[allow(clippy::too_many_lines)]
@@ -680,6 +685,7 @@ fn merge_config(config: &mut Config, env_config: &EnvConfig) {
     merge_option_to_value!(config, env_config, appsec_waf_timeout);
     merge_option_to_value!(config, env_config, api_security_enabled);
     merge_option_to_value!(config, env_config, api_security_sample_delay);
+    merge_string!(config, dd_org_uuid, env_config, org_uuid);
 }
 
 #[derive(Debug, PartialEq, Clone, Copy)]
@@ -880,6 +886,7 @@ mod tests {
                 "arn:aws:ssm:us-east-1:123:parameter/key",
             ),
             ("DD_APPSEC_RULES", "/opt/custom-rules.json"),
+            ("DD_ORG_UUID", "test-org-uuid"),
         ];
 
         // Programmatic guard: count `pub ` fields in the EnvConfig struct from
@@ -955,6 +962,7 @@ mod tests {
                 Some("keep".to_string());
             expected.otlp_config_metrics_summaries_mode = Some("noquantiles".to_string());
             expected.appsec_rules = Some("/opt/custom-rules.json".to_string());
+            expected.dd_org_uuid = "test-org-uuid".to_string();
 
             assert_eq!(config, expected);
             Ok(())
@@ -1282,6 +1290,7 @@ mod tests {
                 appsec_waf_timeout: Duration::from_secs(1),
                 api_security_enabled: false,
                 api_security_sample_delay: Duration::from_secs(60),
+                dd_org_uuid: String::default(),
             };
 
             assert_eq!(config, expected_config);

--- a/crates/datadog-agent-config/mod.rs
+++ b/crates/datadog-agent-config/mod.rs
@@ -368,6 +368,8 @@ pub struct Config {
     pub appsec_waf_timeout: Duration,
     pub api_security_enabled: bool,
     pub api_security_sample_delay: Duration,
+
+    pub dd_org_uuid: String,
 }
 
 impl Default for Config {
@@ -483,6 +485,8 @@ impl Default for Config {
             appsec_waf_timeout: Duration::from_millis(5),
             api_security_enabled: true,
             api_security_sample_delay: Duration::from_secs(30),
+
+            dd_org_uuid: String::default(),
         }
     }
 }

--- a/crates/datadog-agent-config/yaml.rs
+++ b/crates/datadog-agent-config/yaml.rs
@@ -1245,6 +1245,7 @@ api_security_sample_delay: 60 # Seconds
                 dogstatsd_so_rcvbuf: Some(1_048_576),
                 dogstatsd_buffer_size: Some(65507),
                 dogstatsd_queue_size: Some(2048),
+                dd_org_uuid: String::default(),
             };
 
             // Assert that

--- a/crates/datadog-serverless-compat/Cargo.toml
+++ b/crates/datadog-serverless-compat/Cargo.toml
@@ -11,7 +11,7 @@ windows-pipes = ["datadog-trace-agent/windows-pipes", "dogstatsd/windows-pipes"]
 
 [dependencies]
 datadog-trace-agent = { path = "../datadog-trace-agent" }
-libdd-trace-utils = { git = "https://github.com/DataDog/libdatadog", rev = "d52ee90209cb12a28bdda0114535c1a985a29d95" }
+libdd-trace-utils = { git = "https://github.com/DataDog/libdatadog", rev = "8c88979985154d6d97c0fc2ca9039682981eacad" }
 datadog-fips = { path = "../datadog-fips", default-features = false }
 dogstatsd = { path = "../dogstatsd", default-features = true }
 reqwest = { version = "0.12.4", default-features = false }

--- a/crates/datadog-trace-agent/Cargo.toml
+++ b/crates/datadog-trace-agent/Cargo.toml
@@ -24,12 +24,12 @@ async-trait = "0.1.64"
 tracing = { version = "0.1", default-features = false }
 serde = { version = "1.0.145", features = ["derive"] }
 serde_json = "1.0"
-libdd-common = { git = "https://github.com/DataDog/libdatadog", rev = "d52ee90209cb12a28bdda0114535c1a985a29d95" }
-libdd-trace-protobuf = { git = "https://github.com/DataDog/libdatadog", rev = "d52ee90209cb12a28bdda0114535c1a985a29d95" }
-libdd-trace-utils = { git = "https://github.com/DataDog/libdatadog", rev = "d52ee90209cb12a28bdda0114535c1a985a29d95", features = [
+libdd-common = { git = "https://github.com/DataDog/libdatadog", rev = "8c88979985154d6d97c0fc2ca9039682981eacad" }
+libdd-trace-protobuf = { git = "https://github.com/DataDog/libdatadog", rev = "8c88979985154d6d97c0fc2ca9039682981eacad" }
+libdd-trace-utils = { git = "https://github.com/DataDog/libdatadog", rev = "8c88979985154d6d97c0fc2ca9039682981eacad", features = [
     "mini_agent",
 ] }
-libdd-trace-obfuscation = { git = "https://github.com/DataDog/libdatadog", rev = "d52ee90209cb12a28bdda0114535c1a985a29d95" }
+libdd-trace-obfuscation = { git = "https://github.com/DataDog/libdatadog", rev = "8c88979985154d6d97c0fc2ca9039682981eacad" }
 datadog-fips = { path = "../datadog-fips" }
 reqwest = { version = "0.12.23", features = ["json", "http2"], default-features = false }
 bytes = "1.10.1"
@@ -40,6 +40,6 @@ serial_test = "2.0.0"
 duplicate = "0.4.1"
 temp-env = "0.3.6"
 tempfile = "3.3.0"
-libdd-trace-utils = { git = "https://github.com/DataDog/libdatadog", rev = "d52ee90209cb12a28bdda0114535c1a985a29d95", features = [
+libdd-trace-utils = { git = "https://github.com/DataDog/libdatadog", rev = "8c88979985154d6d97c0fc2ca9039682981eacad", features = [
     "test-utils",
 ] }

--- a/crates/datadog-trace-agent/src/env_verifier.rs
+++ b/crates/datadog-trace-agent/src/env_verifier.rs
@@ -4,7 +4,7 @@
 use async_trait::async_trait;
 use http_body_util::BodyExt;
 use hyper::{Method, Request};
-use libdd_common::hyper_migration;
+use libdd_common::http_common;
 use serde::{Deserialize, Serialize};
 use std::env;
 use std::fs;
@@ -186,24 +186,24 @@ fn get_region_from_gcp_region_string(str: String) -> String {
 /// tests
 #[async_trait]
 pub(crate) trait GoogleMetadataClient {
-    async fn get_metadata(&self) -> anyhow::Result<hyper_migration::HttpResponse>;
+    async fn get_metadata(&self) -> anyhow::Result<http_common::HttpResponse>;
 }
 
 struct GoogleMetadataClientWrapper {}
 
 #[async_trait]
 impl GoogleMetadataClient for GoogleMetadataClientWrapper {
-    async fn get_metadata(&self) -> anyhow::Result<hyper_migration::HttpResponse> {
+    async fn get_metadata(&self) -> anyhow::Result<http_common::HttpResponse> {
         let req = Request::builder()
             .method(Method::POST)
             .uri(GCP_METADATA_URL)
             .header("Metadata-Flavor", "Google")
-            .body(hyper_migration::Body::empty())
+            .body(http_common::Body::empty())
             .map_err(|err| anyhow::anyhow!(err.to_string()))?;
 
-        let client = hyper_migration::new_default_client();
+        let client = http_common::new_default_client();
         match client.request(req).await {
-            Ok(res) => Ok(hyper_migration::into_response(res)),
+            Ok(res) => Ok(http_common::into_response(res)),
             Err(err) => anyhow::bail!(err.to_string()),
         }
     }
@@ -243,7 +243,7 @@ async fn ensure_gcp_function_environment(
     Ok(gcp_metadata)
 }
 
-async fn get_gcp_metadata_from_body(body: hyper_migration::Body) -> anyhow::Result<GCPMetadata> {
+async fn get_gcp_metadata_from_body(body: http_common::Body) -> anyhow::Result<GCPMetadata> {
     let bytes = body.collect().await?.to_bytes();
     let body_str = String::from_utf8(bytes.to_vec())?;
     let gcp_metadata: GCPMetadata = serde_json::from_str(&body_str)?;
@@ -361,7 +361,7 @@ async fn ensure_azure_function_environment(
 mod tests {
     use async_trait::async_trait;
     use hyper::{Response, StatusCode, body::Bytes};
-    use libdd_common::hyper_migration;
+    use libdd_common::http_common;
     use libdd_trace_utils::trace_utils;
     use serde_json::json;
     use serial_test::serial;
@@ -382,7 +382,7 @@ mod tests {
         struct MockGoogleMetadataClient {}
         #[async_trait]
         impl GoogleMetadataClient for MockGoogleMetadataClient {
-            async fn get_metadata(&self) -> anyhow::Result<hyper_migration::HttpResponse> {
+            async fn get_metadata(&self) -> anyhow::Result<http_common::HttpResponse> {
                 anyhow::bail!("Random Error")
             }
         }
@@ -401,9 +401,9 @@ mod tests {
         struct MockGoogleMetadataClient {}
         #[async_trait]
         impl GoogleMetadataClient for MockGoogleMetadataClient {
-            async fn get_metadata(&self) -> anyhow::Result<hyper_migration::HttpResponse> {
+            async fn get_metadata(&self) -> anyhow::Result<http_common::HttpResponse> {
                 Ok(
-                    hyper_migration::empty_response(Response::builder().status(StatusCode::OK))
+                    http_common::empty_response(Response::builder().status(StatusCode::OK))
                         .unwrap(),
                 )
             }
@@ -423,8 +423,8 @@ mod tests {
         struct MockGoogleMetadataClient {}
         #[async_trait]
         impl GoogleMetadataClient for MockGoogleMetadataClient {
-            async fn get_metadata(&self) -> anyhow::Result<hyper_migration::HttpResponse> {
-                Ok(hyper_migration::empty_response(
+            async fn get_metadata(&self) -> anyhow::Result<http_common::HttpResponse> {
+                Ok(http_common::empty_response(
                     Response::builder()
                         .status(StatusCode::OK)
                         .header("Server", "Metadata Server NOT for Serverless"),
@@ -447,8 +447,8 @@ mod tests {
         struct MockGoogleMetadataClient {}
         #[async_trait]
         impl GoogleMetadataClient for MockGoogleMetadataClient {
-            async fn get_metadata(&self) -> anyhow::Result<hyper_migration::HttpResponse> {
-                Ok(hyper_migration::mock_response(
+            async fn get_metadata(&self) -> anyhow::Result<http_common::HttpResponse> {
+                Ok(http_common::mock_response(
                     Response::builder()
                         .status(StatusCode::OK)
                         .header("Server", "Metadata Server for Serverless"),
@@ -489,11 +489,11 @@ mod tests {
         struct MockGoogleMetadataClient {}
         #[async_trait]
         impl GoogleMetadataClient for MockGoogleMetadataClient {
-            async fn get_metadata(&self) -> anyhow::Result<hyper_migration::HttpResponse> {
+            async fn get_metadata(&self) -> anyhow::Result<http_common::HttpResponse> {
                 // Sleep for 5 seconds to let the timeout trigger
                 tokio::time::sleep(Duration::from_secs(5)).await;
                 Ok(
-                    hyper_migration::empty_response(Response::builder().status(StatusCode::OK))
+                    http_common::empty_response(Response::builder().status(StatusCode::OK))
                         .unwrap(),
                 )
             }

--- a/crates/datadog-trace-agent/src/http_utils.rs
+++ b/crates/datadog-trace-agent/src/http_utils.rs
@@ -7,7 +7,7 @@ use hyper::{
     Response, StatusCode, header,
     http::{self, HeaderMap},
 };
-use libdd_common::hyper_migration;
+use libdd_common::http_common;
 use serde_json::json;
 use std::error::Error;
 use tracing::{debug, error};
@@ -24,7 +24,7 @@ use tracing::{debug, error};
 pub fn log_and_create_http_response(
     message: &str,
     status: StatusCode,
-) -> http::Result<Response<hyper_migration::Body>> {
+) -> http::Result<Response<http_common::Body>> {
     if status.is_success() {
         debug!("{message}");
     } else {
@@ -33,7 +33,7 @@ pub fn log_and_create_http_response(
     let body = json!({ "message": message }).to_string();
     Response::builder()
         .status(status)
-        .body(hyper_migration::Body::from(body))
+        .body(http_common::Body::from(body))
 }
 
 /// Does two things:
@@ -50,12 +50,12 @@ pub fn log_and_create_http_response(
 pub fn log_and_create_traces_success_http_response(
     message: &str,
     status: StatusCode,
-) -> http::Result<hyper_migration::HttpResponse> {
+) -> http::Result<http_common::HttpResponse> {
     debug!("{message}");
     let body = json!({"rate_by_service":{"service:,env:":1}}).to_string();
     Response::builder()
         .status(status)
-        .body(hyper_migration::Body::from(body))
+        .body(http_common::Body::from(body))
 }
 
 /// Takes a request's header map, and verifies that the "content-length" and/or "Transfer-Encoding" header
@@ -67,7 +67,7 @@ pub fn verify_request_content_length(
     header_map: &HeaderMap,
     max_content_length: usize,
     error_message_prefix: &str,
-) -> Option<http::Result<hyper_migration::HttpResponse>> {
+) -> Option<http::Result<http_common::HttpResponse>> {
     let content_length_header = match header_map.get(header::CONTENT_LENGTH) {
         Some(res) => res,
         None => {
@@ -151,7 +151,7 @@ mod tests {
     use hyper::HeaderMap;
     use hyper::StatusCode;
     use hyper::header;
-    use libdd_common::hyper_migration;
+    use libdd_common::http_common;
 
     use super::is_lambda_lite_from_env;
     use super::verify_request_content_length;
@@ -182,7 +182,7 @@ mod tests {
         map
     }
 
-    async fn get_response_body_as_string(response: hyper_migration::HttpResponse) -> String {
+    async fn get_response_body_as_string(response: http_common::HttpResponse) -> String {
         let body = response.into_body();
         let bytes = body.collect().await.unwrap().to_bytes();
         String::from_utf8(bytes.into_iter().collect()).unwrap()

--- a/crates/datadog-trace-agent/src/http_utils.rs
+++ b/crates/datadog-trace-agent/src/http_utils.rs
@@ -113,6 +113,25 @@ pub fn verify_request_content_length(
     None
 }
 
+/// Environment variable set by the Lambda runtime to indicate the initialisation type.
+/// Lambda Web Adapter (web function / native-http mode) sets this to `"native-http"`;
+/// standard on-demand invocations set it to `"on-demand"`.
+const ENV_LAMBDA_INIT_TYPE: &str = "AWS_LAMBDA_INITIALIZATION_TYPE";
+
+/// Returns true if the current environment is Lambda Lite (web function / native-http mode).
+///
+/// Determined by checking [`ENV_LAMBDA_INIT_TYPE`] == `"native-http"`. This is used to gate
+/// behaviour specific to long-running web server deployments on Lambda Lite.
+pub fn is_lambda_lite() -> bool {
+    is_lambda_lite_from_env(std::env::var(ENV_LAMBDA_INIT_TYPE).ok().as_deref())
+}
+
+// Split out from `is_lambda_lite` for testability — allows injecting the env value in unit tests
+// without mutating process-global state.
+fn is_lambda_lite_from_env(val: Option<&str>) -> bool {
+    val == Some("native-http")
+}
+
 /// Builds a reqwest client with optional proxy configuration and timeout.
 /// Uses rustls TLS by default. FIPS-compliant TLS is available via the fips feature
 pub fn build_client(
@@ -134,7 +153,28 @@ mod tests {
     use hyper::header;
     use libdd_common::hyper_migration;
 
+    use super::is_lambda_lite_from_env;
     use super::verify_request_content_length;
+
+    #[test]
+    fn test_is_lambda_lite_native_http() {
+        assert!(is_lambda_lite_from_env(Some("native-http")));
+    }
+
+    #[test]
+    fn test_is_lambda_lite_on_demand() {
+        assert!(!is_lambda_lite_from_env(Some("on-demand")));
+    }
+
+    #[test]
+    fn test_is_lambda_lite_empty_string() {
+        assert!(!is_lambda_lite_from_env(Some("")));
+    }
+
+    #[test]
+    fn test_is_lambda_lite_unset() {
+        assert!(!is_lambda_lite_from_env(None));
+    }
 
     fn create_test_headers_with_content_length(val: &str) -> HeaderMap {
         let mut map = HeaderMap::new();

--- a/crates/datadog-trace-agent/src/mini_agent.rs
+++ b/crates/datadog-trace-agent/src/mini_agent.rs
@@ -4,7 +4,7 @@
 use http_body_util::BodyExt;
 use hyper::service::service_fn;
 use hyper::{Method, Response, StatusCode, http};
-use libdd_common::hyper_migration;
+use libdd_common::http_common;
 use serde_json::json;
 use std::io;
 use std::net::SocketAddr;
@@ -125,7 +125,7 @@ impl MiniAgent {
 
             MiniAgent::trace_endpoint_handler(
                 endpoint_config,
-                req.map(hyper_migration::Body::incoming),
+                req.map(http_common::Body::incoming),
                 trace_processor,
                 trace_tx,
                 stats_processor,
@@ -231,7 +231,7 @@ impl MiniAgent {
     where
         S: hyper::service::Service<
                 hyper::Request<hyper::body::Incoming>,
-                Response = hyper::Response<hyper_migration::Body>,
+                Response = hyper::Response<http_common::Body>,
             > + Clone
             + Send
             + 'static,
@@ -302,7 +302,7 @@ impl MiniAgent {
     where
         S: hyper::service::Service<
                 hyper::Request<hyper::body::Incoming>,
-                Response = hyper::Response<hyper_migration::Body>,
+                Response = hyper::Response<http_common::Body>,
             > + Clone
             + Send
             + 'static,
@@ -385,14 +385,14 @@ impl MiniAgent {
     #[allow(clippy::too_many_arguments)]
     async fn trace_endpoint_handler(
         config: Arc<config::Config>,
-        req: hyper_migration::HttpRequest,
+        req: http_common::HttpRequest,
         trace_processor: Arc<dyn trace_processor::TraceProcessor + Send + Sync>,
         trace_tx: Sender<SendData>,
         stats_processor: Arc<dyn stats_processor::StatsProcessor + Send + Sync>,
         stats_tx: Sender<pb::ClientStatsPayload>,
         mini_agent_metadata: Arc<trace_utils::MiniAgentMetadata>,
         proxy_tx: Sender<ProxyRequest>,
-    ) -> http::Result<hyper_migration::HttpResponse> {
+    ) -> http::Result<http_common::HttpResponse> {
         match (req.method(), req.uri().path()) {
             (&Method::PUT | &Method::POST, TRACE_ENDPOINT_PATH) => {
                 match trace_processor
@@ -449,9 +449,9 @@ impl MiniAgent {
     /// Handles incoming proxy requests for profiling - can be abstracted into a generic proxy handler for other proxy requests in the future
     async fn profiling_proxy_handler(
         config: Arc<config::Config>,
-        request: hyper_migration::HttpRequest,
+        request: http_common::HttpRequest,
         proxy_tx: Sender<ProxyRequest>,
-    ) -> http::Result<hyper_migration::HttpResponse> {
+    ) -> http::Result<http_common::HttpResponse> {
         debug!("Received profiling request");
 
         // Extract headers and body
@@ -503,7 +503,7 @@ impl MiniAgent {
         dd_apm_receiver_port: u16,
         dd_apm_windows_pipe_name: Option<&str>,
         dd_dogstatsd_port: u16,
-    ) -> http::Result<hyper_migration::HttpResponse> {
+    ) -> http::Result<http_common::HttpResponse> {
         // pipe_name already includes \\.\pipe\ prefix from config
         let receiver_socket = dd_apm_windows_pipe_name.unwrap_or("");
 
@@ -527,6 +527,6 @@ impl MiniAgent {
         );
         Response::builder()
             .status(200)
-            .body(hyper_migration::Body::from(response_json.to_string()))
+            .body(http_common::Body::from(response_json.to_string()))
     }
 }

--- a/crates/datadog-trace-agent/src/mini_agent.rs
+++ b/crates/datadog-trace-agent/src/mini_agent.rs
@@ -11,7 +11,7 @@ use std::net::SocketAddr;
 use std::sync::Arc;
 use std::time::Instant;
 use tokio::sync::mpsc::{self, Receiver, Sender};
-use tracing::{debug, error};
+use tracing::{debug, error, warn};
 
 use crate::http_utils::{log_and_create_http_response, verify_request_content_length};
 use crate::proxy_flusher::{ProxyFlusher, ProxyRequest};
@@ -31,6 +31,13 @@ const PROFILING_ENDPOINT_PATH: &str = "/profiling/v1/input";
 const TRACER_PAYLOAD_CHANNEL_BUFFER_SIZE: usize = 10;
 const STATS_PAYLOAD_CHANNEL_BUFFER_SIZE: usize = 10;
 const PROXY_PAYLOAD_CHANNEL_BUFFER_SIZE: usize = 10;
+/// Sentinel file written on startup in Lambda Lite mode.
+/// dd-trace (Node.js) checks this path via DATADOG_MINI_AGENT_PATH in constants.js
+/// (datadog/dd-trace-js) to decide whether to switch from LogExporter (stdout) to
+/// AgentExporter (HTTP :8126).
+/// The parent directory `/tmp/datadog/` is created by the serverless-compat JS layer
+/// before this binary is spawned.
+const LAMBDA_LITE_SENTINEL_PATH: &str = "/tmp/datadog/mini_agent_ready";
 
 pub struct MiniAgent {
     pub config: Arc<config::Config>,
@@ -172,6 +179,36 @@ impl MiniAgent {
             // TCP transport
             let addr = SocketAddr::from(([127, 0, 0, 1], self.config.dd_apm_receiver_port));
             let listener = tokio::net::TcpListener::bind(&addr).await?;
+
+            // Write the sentinel file after the listener is bound so that dd-trace
+            // (Node.js) only switches from LogExporter (stdout) to AgentExporter
+            // (HTTP :8126) once the port is actually ready to accept connections.
+            // Only written for Lambda Lite; standard Lambda invocations use the
+            // Extension path (/opt/extensions/datadog-agent) instead.
+            // /opt is read-only in Lambda Lite, so we use /tmp/datadog/ (created
+            // by the serverless-compat JS layer before spawning this binary).
+            if crate::http_utils::is_lambda_lite() {
+                let sentinel = std::path::Path::new(LAMBDA_LITE_SENTINEL_PATH);
+                // SAFETY: LAMBDA_LITE_SENTINEL_PATH is a hard-coded absolute path,
+                // so .parent() always returns Some.
+                if let Some(parent) = sentinel.parent() {
+                    if let Err(e) = tokio::fs::create_dir_all(parent).await {
+                        error!(
+                            "Could not create parent directory for Lambda Lite sentinel \
+                             file at {}: {}.",
+                            LAMBDA_LITE_SENTINEL_PATH, e
+                        );
+                    }
+                }
+                if let Err(e) = tokio::fs::write(sentinel, b"").await {
+                    error!(
+                        "Could not write Lambda Lite sentinel file at {}: {}. \
+                         dd-trace (Node.js) will fall back to LogExporter (stdout), \
+                         traces may not reach Datadog.",
+                        LAMBDA_LITE_SENTINEL_PATH, e
+                    );
+                }
+            }
 
             Self::serve_tcp(
                 listener,

--- a/crates/datadog-trace-agent/src/stats_processor.rs
+++ b/crates/datadog-trace-agent/src/stats_processor.rs
@@ -6,7 +6,7 @@ use std::time::UNIX_EPOCH;
 
 use async_trait::async_trait;
 use hyper::{StatusCode, http};
-use libdd_common::hyper_migration;
+use libdd_common::http_common;
 use tokio::sync::mpsc::Sender;
 use tracing::debug;
 
@@ -23,9 +23,9 @@ pub trait StatsProcessor {
     async fn process_stats(
         &self,
         config: Arc<Config>,
-        req: hyper_migration::HttpRequest,
+        req: http_common::HttpRequest,
         tx: Sender<pb::ClientStatsPayload>,
-    ) -> http::Result<hyper_migration::HttpResponse>;
+    ) -> http::Result<http_common::HttpResponse>;
 }
 
 #[derive(Clone)]
@@ -36,9 +36,9 @@ impl StatsProcessor for ServerlessStatsProcessor {
     async fn process_stats(
         &self,
         config: Arc<Config>,
-        req: hyper_migration::HttpRequest,
+        req: http_common::HttpRequest,
         tx: Sender<pb::ClientStatsPayload>,
-    ) -> http::Result<hyper_migration::HttpResponse> {
+    ) -> http::Result<http_common::HttpResponse> {
         debug!("Received trace stats to process");
         let (parts, body) = req.into_parts();
 

--- a/crates/datadog-trace-agent/src/trace_flusher.rs
+++ b/crates/datadog-trace-agent/src/trace_flusher.rs
@@ -6,7 +6,7 @@ use std::{error::Error, sync::Arc, time};
 use tokio::sync::{Mutex, mpsc::Receiver};
 use tracing::{debug, error};
 
-use libdd_common::{GenericHttpClient, hyper_migration};
+use libdd_common::{GenericHttpClient, http_common};
 use libdd_trace_utils::trace_utils;
 use libdd_trace_utils::trace_utils::SendData;
 
@@ -111,12 +111,12 @@ impl ServerlessTraceFlusher {
                 libdd_common::connector::Connector::default(),
                 proxy,
             )?;
-            Ok(hyper_migration::client_builder().build(proxy_connector))
+            Ok(http_common::client_builder().build(proxy_connector))
         } else {
             let proxy_connector = hyper_http_proxy::ProxyConnector::new(
                 libdd_common::connector::Connector::default(),
             )?;
-            Ok(hyper_migration::client_builder().build(proxy_connector))
+            Ok(http_common::client_builder().build(proxy_connector))
         }
     }
 }

--- a/crates/datadog-trace-agent/src/trace_processor.rs
+++ b/crates/datadog-trace-agent/src/trace_processor.rs
@@ -5,7 +5,7 @@ use std::sync::Arc;
 
 use async_trait::async_trait;
 use hyper::{StatusCode, http};
-use libdd_common::hyper_migration;
+use libdd_common::http_common;
 use tokio::sync::mpsc::Sender;
 use tracing::debug;
 
@@ -29,10 +29,10 @@ pub trait TraceProcessor {
     async fn process_traces(
         &self,
         config: Arc<Config>,
-        req: hyper_migration::HttpRequest,
+        req: http_common::HttpRequest,
         tx: Sender<trace_utils::SendData>,
         mini_agent_metadata: Arc<trace_utils::MiniAgentMetadata>,
-    ) -> http::Result<hyper_migration::HttpResponse>;
+    ) -> http::Result<http_common::HttpResponse>;
 }
 
 struct ChunkProcessor {
@@ -72,10 +72,10 @@ impl TraceProcessor for ServerlessTraceProcessor {
     async fn process_traces(
         &self,
         config: Arc<Config>,
-        req: hyper_migration::HttpRequest,
+        req: http_common::HttpRequest,
         tx: Sender<trace_utils::SendData>,
         mini_agent_metadata: Arc<trace_utils::MiniAgentMetadata>,
-    ) -> http::Result<hyper_migration::HttpResponse> {
+    ) -> http::Result<http_common::HttpResponse> {
         debug!("Received traces to process");
         let (parts, body) = req.into_parts();
 
@@ -170,7 +170,7 @@ mod tests {
         config::{Config, Tags},
         trace_processor::{self, TRACER_PAYLOAD_FUNCTION_TAGS_TAG_KEY, TraceProcessor},
     };
-    use libdd_common::{Endpoint, hyper_migration};
+    use libdd_common::{Endpoint, http_common};
     use libdd_trace_protobuf::pb;
     use libdd_trace_utils::test_utils::{create_test_gcp_json_span, create_test_gcp_span};
     use libdd_trace_utils::trace_utils::MiniAgentMetadata;
@@ -251,7 +251,7 @@ mod tests {
             .header("datadog-meta-lang-interpreter", "v8")
             .header("datadog-container-id", "33")
             .header("content-length", "100")
-            .body(hyper_migration::Body::from(bytes))
+            .body(http_common::Body::from(bytes))
             .unwrap();
 
         let trace_processor = trace_processor::ServerlessTraceProcessor {};
@@ -323,7 +323,7 @@ mod tests {
             .header("datadog-meta-lang-interpreter", "v8")
             .header("datadog-container-id", "33")
             .header("content-length", "100")
-            .body(hyper_migration::Body::from(bytes))
+            .body(http_common::Body::from(bytes))
             .unwrap();
 
         let trace_processor = trace_processor::ServerlessTraceProcessor {};

--- a/crates/datadog-trace-agent/tests/common/helpers.rs
+++ b/crates/datadog-trace-agent/tests/common/helpers.rs
@@ -5,7 +5,7 @@
 
 use hyper::{Request, Response};
 use hyper_util::rt::TokioIo;
-use libdd_common::hyper_migration;
+use libdd_common::http_common;
 use libdd_trace_utils::test_utils::create_test_json_span;
 use std::time::{Duration, UNIX_EPOCH};
 use tokio::time::timeout;
@@ -45,10 +45,10 @@ pub async fn send_tcp_request(
     let response = if let Some(body_data) = body {
         let body_len = body_data.len();
         request_builder = request_builder.header("Content-Length", body_len.to_string());
-        let request = request_builder.body(hyper_migration::Body::from(body_data))?;
+        let request = request_builder.body(http_common::Body::from(body_data))?;
         timeout(Duration::from_secs(2), sender.send_request(request)).await??
     } else {
-        let request = request_builder.body(hyper_migration::Body::empty())?;
+        let request = request_builder.body(http_common::Body::empty())?;
         timeout(Duration::from_secs(2), sender.send_request(request)).await??
     };
 
@@ -83,10 +83,10 @@ pub async fn send_named_pipe_request(
     let response = if let Some(body_data) = body {
         let body_len = body_data.len();
         request_builder = request_builder.header("Content-Length", body_len.to_string());
-        let request = request_builder.body(hyper_migration::Body::from(body_data))?;
+        let request = request_builder.body(http_common::Body::from(body_data))?;
         timeout(Duration::from_secs(2), sender.send_request(request)).await??
     } else {
-        let request = request_builder.body(hyper_migration::Body::empty())?;
+        let request = request_builder.body(http_common::Body::empty())?;
         timeout(Duration::from_secs(2), sender.send_request(request)).await??
     };
 

--- a/crates/datadog-trace-agent/tests/common/mock_server.rs
+++ b/crates/datadog-trace-agent/tests/common/mock_server.rs
@@ -6,7 +6,7 @@
 use http_body_util::BodyExt;
 use hyper::{Request, Response, body::Incoming};
 use hyper_util::rt::TokioIo;
-use libdd_common::hyper_migration;
+use libdd_common::http_common;
 use std::net::SocketAddr;
 use std::sync::{Arc, Mutex};
 use tokio::net::TcpListener;
@@ -86,7 +86,7 @@ impl MockServer {
                                     Ok::<_, hyper::http::Error>(
                                         Response::builder()
                                             .status(200)
-                                            .body(hyper_migration::Body::from(r#"{"ok":true}"#))
+                                            .body(http_common::Body::from(r#"{"ok":true}"#))
                                             .unwrap(),
                                     )
                                 }

--- a/crates/datadog-trace-agent/tests/common/mocks.rs
+++ b/crates/datadog-trace-agent/tests/common/mocks.rs
@@ -7,7 +7,7 @@ use datadog_trace_agent::{
     config::Config, env_verifier::EnvVerifier, stats_flusher::StatsFlusher,
     stats_processor::StatsProcessor, trace_flusher::TraceFlusher, trace_processor::TraceProcessor,
 };
-use libdd_common::hyper_migration;
+use libdd_common::http_common;
 use libdd_trace_protobuf::pb;
 use libdd_trace_utils::trace_utils::{self, MiniAgentMetadata, SendData};
 use std::sync::Arc;
@@ -22,13 +22,13 @@ impl TraceProcessor for MockTraceProcessor {
     async fn process_traces(
         &self,
         _config: Arc<Config>,
-        _req: hyper_migration::HttpRequest,
+        _req: http_common::HttpRequest,
         _trace_tx: Sender<SendData>,
         _mini_agent_metadata: Arc<MiniAgentMetadata>,
-    ) -> Result<hyper_migration::HttpResponse, hyper::http::Error> {
+    ) -> Result<http_common::HttpResponse, hyper::http::Error> {
         hyper::Response::builder()
             .status(200)
-            .body(hyper_migration::Body::from("{}"))
+            .body(http_common::Body::from("{}"))
     }
 }
 
@@ -68,12 +68,12 @@ impl StatsProcessor for MockStatsProcessor {
     async fn process_stats(
         &self,
         _config: Arc<Config>,
-        _req: hyper_migration::HttpRequest,
+        _req: http_common::HttpRequest,
         _stats_tx: Sender<pb::ClientStatsPayload>,
-    ) -> Result<hyper_migration::HttpResponse, hyper::http::Error> {
+    ) -> Result<http_common::HttpResponse, hyper::http::Error> {
         hyper::Response::builder()
             .status(200)
-            .body(hyper_migration::Body::from("{}"))
+            .body(http_common::Body::from("{}"))
     }
 }
 

--- a/npm/datadog-serverless-compat-darwin-arm64/package.json
+++ b/npm/datadog-serverless-compat-darwin-arm64/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "@datadog/serverless-compat-darwin-arm64",
+  "version": "0.0.0",
+  "description": "macOS arm64 binary for the Datadog Serverless Compatibility Layer",
+  "os": [
+    "darwin"
+  ],
+  "cpu": [
+    "arm64"
+  ],
+  "files": [
+    "bin/"
+  ],
+  "publishConfig": {
+    "access": "public",
+    "executableFiles": [
+      "./bin/datadog-serverless-compat"
+    ]
+  },
+  "license": "Apache-2.0",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/DataDog/serverless-components"
+  }
+}

--- a/npm/datadog-serverless-compat-win32-ia32/package.json
+++ b/npm/datadog-serverless-compat-win32-ia32/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "@datadog/serverless-compat-win32-ia32",
+  "version": "0.0.0",
+  "description": "Windows ia32 binary for the Datadog Serverless Compatibility Layer",
+  "os": [
+    "win32"
+  ],
+  "cpu": [
+    "ia32"
+  ],
+  "files": [
+    "bin/"
+  ],
+  "publishConfig": {
+    "access": "public"
+  },
+  "license": "Apache-2.0",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/DataDog/serverless-components"
+  }
+}


### PR DESCRIPTION
## Summary

- Adds `DD_ORG_UUID` (`org_uuid`) field to `EnvConfig` in the `datadog-agent-config` crate
- Adds `dd_org_uuid: String` to the `Config` struct with an empty string default
- Wires up the `merge_string!` so the env var is applied during config loading

## Context

This field is needed to support delegated AWS authentication in the Lambda extension (DataDog/datadog-lambda-extension#1112). When `DD_ORG_UUID` is set, the extension uses AWS credentials to obtain a managed API key instead of requiring a static `DD_API_KEY`. Adding it to the shared crate makes it available to other consumers.

## Test plan

- [x] Existing `test_all_env_fields_wrong_type_fallback_to_default` field-count guard updated
- [x] All 78 `datadog-agent-config` tests pass

🤖 Generated with [Claude Code](https://claude.ai/claude-code)