### PR TITLE
Enhancement/dd env type override

### DIFF
--- a/crates/datadog-serverless-compat/src/main.rs
+++ b/crates/datadog-serverless-compat/src/main.rs
@@ -63,7 +63,9 @@ pub async fn main() {
             "cloudfunction" => env_type = EnvironmentType::CloudFunction,
             "azurefunction" => env_type = EnvironmentType::AzureFunction,
             "azurespringapp" => env_type = EnvironmentType::AzureSpringApp,
-            _ => {}
+            _ => {
+                debug!("DD_ENV_TYPE value not recognized, env_type not overwritten");
+            }
         }
     }
 

--- a/crates/datadog-serverless-compat/src/main.rs
+++ b/crates/datadog-serverless-compat/src/main.rs
@@ -50,13 +50,22 @@ pub async fn main() {
         .map(|val| val.to_lowercase())
         .unwrap_or("info".to_string());
 
-    let (_, env_type) = match read_cloud_env() {
+    let (_, mut env_type) = match read_cloud_env() {
         Some(value) => value,
         None => {
             error!("Unable to identify environment. Shutting down Mini Agent.");
             return;
         }
     };
+
+    if let Ok(res) = env::var("DD_ENV_TYPE") {
+        match res.to_lowercase().as_str() {
+            "cloudfunction" => env_type = EnvironmentType::CloudFunction,
+            "azurefunction" => env_type = EnvironmentType::AzureFunction,
+            "azurespringapp" => env_type = EnvironmentType::AzureSpringApp,
+            _ => {}
+        }
+    }
 
     let dogstatsd_tags = match env_type {
         EnvironmentType::CloudFunction => "origin:cloudfunction,dd.origin:cloudfunction",


### PR DESCRIPTION
### What does this PR do?

This PR introduces support for explicitly overriding the detected cloud environment via the `DD_ENV_TYPE` environment variable.

If `DD_ENV_TYPE` is set, the mini agent will prioritize this value over the automatically detected environment from `read_cloud_env()`. Currently supported values are:

- `cloudfunction`
- `azurefunction`
- `azurespringapp`

If the value is not recognized, the existing auto-detection logic remains unchanged.

---

### Motivation

We encountered an issue where the environment detection logic incorrectly classified the runtime environment due to the presence of a generic environment variable (`FUNCTION_NAME`).
The function responsible for this is [read_cloud_env()](https://github.com/DataDog/libdatadog/blob/0a2a9a8136d70598bf13f0e0a2cc84ad6015ab12/libdd-trace-utils/src/config_utils.rs#L12-L33)

In our specific case, Azure Functions were misidentified as Google Cloud Functions because `FUNCTION_NAME` was set by internal tooling. This led to incorrect behavior of the serverless mini agent.

As part of debugging (see support ticket below), we identified that:

- `FUNCTION_NAME` is too generic to reliably indicate the environment
- The environment detection logic can produce misleading results without clear visibility
- This caused significant debugging effort, as the root cause was not obvious

To resolve this, we:
- Switched internally to `AZURE_FUNCTION_NAME`
- Added this override mechanism (`DD_ENV_TYPE`) to allow explicit control

Support ticket:
https://help.datadoghq.com/hc/en-us/requests/2771896?brand_id=284865

Relevant excerpt from investigation:

> Our colleagues use the environment variable FUNCTION_NAME in their Azure function which led to the wrong detection of the cloud environment.  
> So we changed it to AZURE_FUNCTION_NAME and also needed to update all the code where the env var FUNCTION_NAME was used.  
>  
> FUNCTION_NAME is way too generic to pin it down to GCP only. Additionally it should be documented and error messages should be more precise, as it took significant time to identify the root cause.

---

### Additional Notes

- This change is fully backward compatible
- It does not modify existing detection logic unless `DD_ENV_TYPE` is explicitly set
- Improves debuggability and control in multi-cloud or custom environments
- Helps avoid ambiguous environment detection caused by generic environment variables

---

### Describe how to test/QA your changes

**Manual testing:**

1. Run the mini agent without `DD_ENV_TYPE`
   - Verify existing environment detection behavior remains unchanged

2. Set `DD_ENV_TYPE=azurefunction`
   - Verify `env_type` is correctly overridden to `AzureFunction`
   - Confirm correct DogStatsD tags:
     origin:azurefunction,dd.origin:azurefunction

3. Set `DD_ENV_TYPE=cloudfunction`
   - Verify override works for GCP

4. Set an invalid value (e.g. `DD_ENV_TYPE=unknown`)
   - Verify fallback to auto-detection
   - Confirm debug log message is emitted

5. Reproduce original issue scenario:
   - Set `FUNCTION_NAME` in environment
   - Confirm that without override → wrong detection
   - With `DD_ENV_TYPE` → correct behavior

**Regression safety:**
- No existing logic paths are altered unless the new env var is used
- No breaking changes expected
