### PR TITLE
[SVLS-8799] Update libdatadog revision to 986aab55cb7941d8453dffb59d35a70599d08665

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -448,7 +448,7 @@ dependencies = [
  "dogstatsd",
  "figment",
  "libdd-trace-obfuscation",
- "libdd-trace-utils 3.0.0",
+ "libdd-trace-utils 3.0.1",
  "log",
  "serde",
  "serde-aux",
@@ -542,7 +542,7 @@ dependencies = [
  "datadog-logs-agent",
  "datadog-trace-agent",
  "dogstatsd",
- "libdd-trace-utils 3.0.0",
+ "libdd-trace-utils 3.0.1",
  "reqwest",
  "serde_json",
  "tokio",
@@ -565,10 +565,10 @@ dependencies = [
  "hyper",
  "hyper-http-proxy",
  "hyper-util",
- "libdd-common 3.0.1",
+ "libdd-common 3.0.2",
  "libdd-trace-obfuscation",
- "libdd-trace-protobuf 3.0.0",
- "libdd-trace-utils 3.0.0",
+ "libdd-trace-protobuf 3.0.1",
+ "libdd-trace-utils 3.0.1",
  "reqwest",
  "rmp-serde",
  "serde",
@@ -1427,6 +1427,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b5b646652bf6661599e1da8901b3b9522896f01e736bad5f723fe7a3a27f899d"
 
 [[package]]
+name = "libdd-capabilities"
+version = "0.1.0"
+source = "git+https://github.com/DataDog/libdatadog?rev=986aab55cb7941d8453dffb59d35a70599d08665#986aab55cb7941d8453dffb59d35a70599d08665"
+dependencies = [
+ "anyhow",
+ "bytes",
+ "http",
+ "thiserror 1.0.69",
+]
+
+[[package]]
+name = "libdd-capabilities-impl"
+version = "0.1.0"
+source = "git+https://github.com/DataDog/libdatadog?rev=986aab55cb7941d8453dffb59d35a70599d08665#986aab55cb7941d8453dffb59d35a70599d08665"
+dependencies = [
+ "bytes",
+ "http",
+ "libdd-capabilities",
+ "libdd-common 3.0.2",
+]
+
+[[package]]
 name = "libdd-common"
 version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1459,8 +1481,8 @@ dependencies = [
 
 [[package]]
 name = "libdd-common"
-version = "3.0.1"
-source = "git+https://github.com/DataDog/libdatadog?rev=8c88979985154d6d97c0fc2ca9039682981eacad#8c88979985154d6d97c0fc2ca9039682981eacad"
+version = "3.0.2"
+source = "git+https://github.com/DataDog/libdatadog?rev=986aab55cb7941d8453dffb59d35a70599d08665#986aab55cb7941d8453dffb59d35a70599d08665"
 dependencies = [
  "anyhow",
  "bytes",
@@ -1477,6 +1499,7 @@ dependencies = [
  "hyper-rustls",
  "hyper-util",
  "libc",
+ "libdd-capabilities",
  "nix",
  "pin-project",
  "regex",
@@ -1581,7 +1604,7 @@ dependencies = [
 [[package]]
 name = "libdd-tinybytes"
 version = "1.1.0"
-source = "git+https://github.com/DataDog/libdatadog?rev=8c88979985154d6d97c0fc2ca9039682981eacad#8c88979985154d6d97c0fc2ca9039682981eacad"
+source = "git+https://github.com/DataDog/libdatadog?rev=986aab55cb7941d8453dffb59d35a70599d08665#986aab55cb7941d8453dffb59d35a70599d08665"
 dependencies = [
  "serde",
 ]
@@ -1598,23 +1621,23 @@ dependencies = [
 
 [[package]]
 name = "libdd-trace-normalization"
-version = "1.0.3"
-source = "git+https://github.com/DataDog/libdatadog?rev=8c88979985154d6d97c0fc2ca9039682981eacad#8c88979985154d6d97c0fc2ca9039682981eacad"
+version = "2.0.0"
+source = "git+https://github.com/DataDog/libdatadog?rev=986aab55cb7941d8453dffb59d35a70599d08665#986aab55cb7941d8453dffb59d35a70599d08665"
 dependencies = [
  "anyhow",
- "libdd-trace-protobuf 3.0.0",
+ "libdd-trace-protobuf 3.0.1",
 ]
 
 [[package]]
 name = "libdd-trace-obfuscation"
-version = "1.0.1"
-source = "git+https://github.com/DataDog/libdatadog?rev=8c88979985154d6d97c0fc2ca9039682981eacad#8c88979985154d6d97c0fc2ca9039682981eacad"
+version = "2.0.0"
+source = "git+https://github.com/DataDog/libdatadog?rev=986aab55cb7941d8453dffb59d35a70599d08665#986aab55cb7941d8453dffb59d35a70599d08665"
 dependencies = [
  "anyhow",
  "fluent-uri",
- "libdd-common 3.0.1",
- "libdd-trace-protobuf 3.0.0",
- "libdd-trace-utils 3.0.0",
+ "libdd-common 3.0.2",
+ "libdd-trace-protobuf 3.0.1",
+ "libdd-trace-utils 3.0.1",
  "log",
  "percent-encoding",
  "regex",
@@ -1635,8 +1658,8 @@ dependencies = [
 
 [[package]]
 name = "libdd-trace-protobuf"
-version = "3.0.0"
-source = "git+https://github.com/DataDog/libdatadog?rev=8c88979985154d6d97c0fc2ca9039682981eacad#8c88979985154d6d97c0fc2ca9039682981eacad"
+version = "3.0.1"
+source = "git+https://github.com/DataDog/libdatadog?rev=986aab55cb7941d8453dffb59d35a70599d08665#986aab55cb7941d8453dffb59d35a70599d08665"
 dependencies = [
  "prost 0.14.3",
  "serde",
@@ -1685,25 +1708,29 @@ dependencies = [
 
 [[package]]
 name = "libdd-trace-utils"
-version = "3.0.0"
-source = "git+https://github.com/DataDog/libdatadog?rev=8c88979985154d6d97c0fc2ca9039682981eacad#8c88979985154d6d97c0fc2ca9039682981eacad"
+version = "3.0.1"
+source = "git+https://github.com/DataDog/libdatadog?rev=986aab55cb7941d8453dffb59d35a70599d08665#986aab55cb7941d8453dffb59d35a70599d08665"
 dependencies = [
  "anyhow",
+ "base64 0.22.1",
  "bytes",
  "cargo-platform",
  "cargo_metadata",
  "flate2",
  "futures",
+ "getrandom 0.2.17",
  "http",
  "http-body",
  "http-body-util",
  "httpmock",
  "hyper",
  "indexmap",
- "libdd-common 3.0.1",
- "libdd-tinybytes 1.1.0 (git+https://github.com/DataDog/libdatadog?rev=8c88979985154d6d97c0fc2ca9039682981eacad)",
- "libdd-trace-normalization 1.0.3",
- "libdd-trace-protobuf 3.0.0",
+ "libdd-capabilities",
+ "libdd-capabilities-impl",
+ "libdd-common 3.0.2",
+ "libdd-tinybytes 1.1.0 (git+https://github.com/DataDog/libdatadog?rev=986aab55cb7941d8453dffb59d35a70599d08665)",
+ "libdd-trace-normalization 2.0.0",
+ "libdd-trace-protobuf 3.0.1",
  "prost 0.14.3",
  "rand 0.8.6",
  "rmp",
@@ -1901,9 +1928,9 @@ checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
 
 [[package]]
 name = "openssl-probe"
-version = "0.2.1"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
+checksum = "d05e27ee213611ffe7d6348b942e8f942b37114c00cc03cec254295a4a17852e"
 
 [[package]]
 name = "opentelemetry"
@@ -2625,9 +2652,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-native-certs"
-version = "0.8.3"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "612460d5f7bea540c490b2b6395d8e34a953e52b491accd6c86c8164c5932a63"
+checksum = "9980d917ebb0c0536119ba501e90834767bffc3d60641457fd84a1f3fd337923"
 dependencies = [
  "openssl-probe",
  "rustls-pki-types",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -565,6 +565,7 @@ dependencies = [
  "hyper",
  "hyper-http-proxy",
  "hyper-util",
+ "libdd-capabilities",
  "libdd-common 3.0.2",
  "libdd-trace-obfuscation",
  "libdd-trace-protobuf 3.0.1",

--- a/LICENSE-3rdparty.csv
+++ b/LICENSE-3rdparty.csv
@@ -11,9 +11,6 @@ async-object-pool,https://github.com/alexliesenfeld/async-object-pool,MIT,Alexan
 async-trait,https://github.com/dtolnay/async-trait,MIT OR Apache-2.0,David Tolnay <dtolnay@gmail.com>
 atomic,https://github.com/Amanieu/atomic-rs,Apache-2.0 OR MIT,Amanieu d'Antras <amanieu@gmail.com>
 atomic-waker,https://github.com/smol-rs/atomic-waker,Apache-2.0 OR MIT,"Stjepan Glavina <stjepang@gmail.com>, Contributors to futures-rs"
-aws-lc-fips-sys,https://github.com/aws/aws-lc-rs,ISC AND (Apache-2.0 OR ISC) AND OpenSSL,AWS-LC
-aws-lc-rs,https://github.com/aws/aws-lc-rs,ISC AND (Apache-2.0 OR ISC),AWS-LibCrypto
-aws-lc-sys,https://github.com/aws/aws-lc-rs,ISC AND (Apache-2.0 OR ISC) AND Apache-2.0 AND MIT AND BSD-3-Clause AND (Apache-2.0 OR ISC OR MIT) AND (Apache-2.0 OR ISC OR MIT-0),AWS-LC
 base64,https://github.com/marshallpierce/rust-base64,MIT OR Apache-2.0,"Alice Maz <alice@alicemaz.com>, Marshall Pierce <marshall@mpierce.org>"
 base64,https://github.com/marshallpierce/rust-base64,MIT OR Apache-2.0,Marshall Pierce <marshall@mpierce.org>
 bit-set,https://github.com/contain-rs/bit-set,Apache-2.0 OR MIT,Alexis Beingessner <a.beingessner@gmail.com>
@@ -30,9 +27,7 @@ camino,https://github.com/camino-rs/camino,MIT OR Apache-2.0,"Without Boats <sao
 cargo-platform,https://github.com/rust-lang/cargo,MIT OR Apache-2.0,The cargo-platform Authors
 cargo_metadata,https://github.com/oli-obk/cargo_metadata,MIT,Oliver Schneider <git-spam-no-reply9815368754983@oli-obk.de>
 cc,https://github.com/rust-lang/cc-rs,MIT OR Apache-2.0,Alex Crichton <alex@alexcrichton.com>
-cexpr,https://github.com/jethrogb/rust-cexpr,Apache-2.0 OR MIT,Jethro Beekman <jethro@jbeekman.nl>
 cfg-if,https://github.com/rust-lang/cfg-if,MIT OR Apache-2.0,Alex Crichton <alex@alexcrichton.com>
-clang-sys,https://github.com/KyleMayes/clang-sys,Apache-2.0,Kyle Mayes <kyle@mayeses.com>
 concurrent-queue,https://github.com/smol-rs/concurrent-queue,Apache-2.0 OR MIT,"Stjepan Glavina <stjepang@gmail.com>, Taiki Endo <te316e89@gmail.com>, John Nunley <dev@notgull.net>"
 const_format,https://github.com/rodrimati1992/const_format_crates,Zlib,rodrimati1992 <rodrimatt1985@gmail.com>
 const_format_proc_macros,https://github.com/rodrimati1992/const_format_crates,Zlib,rodrimati1992 <rodrimatt1985@gmail.com>
@@ -78,7 +73,6 @@ futures-timer,https://github.com/async-rs/futures-timer,MIT OR Apache-2.0,Alex C
 futures-util,https://github.com/rust-lang/futures-rs,MIT OR Apache-2.0,The futures-util Authors
 generic-array,https://github.com/fizyk20/generic-array,MIT,"Bartłomiej Kamiński <fizyk20@gmail.com>, Aaron Trent <novacrazy@gmail.com>"
 getrandom,https://github.com/rust-random/getrandom,MIT OR Apache-2.0,The Rand Project Developers
-glob,https://github.com/rust-lang/glob,MIT OR Apache-2.0,The Rust Project Developers
 h2,https://github.com/hyperium/h2,MIT,"Carl Lerche <me@carllerche.com>, Sean McArthur <sean@seanmonstar.com>"
 hashbrown,https://github.com/rust-lang/hashbrown,MIT OR Apache-2.0,Amanieu d'Antras <amanieu@gmail.com>
 headers,https://github.com/hyperium/headers,MIT,Sean McArthur <sean@seanmonstar.com>
@@ -117,6 +111,8 @@ js-sys,https://github.com/wasm-bindgen/wasm-bindgen/tree/master/crates/js-sys,MI
 lazy_static,https://github.com/rust-lang-nursery/lazy-static.rs,MIT OR Apache-2.0,Marvin Löbel <loebel.marvin@gmail.com>
 leb128fmt,https://github.com/bluk/leb128fmt,MIT OR Apache-2.0,Bryant Luk <code@bryantluk.com>
 libc,https://github.com/rust-lang/libc,MIT OR Apache-2.0,The Rust Project Developers
+libdd-capabilities,https://github.com/DataDog/libdatadog/tree/main/libdd-capabilities,Apache-2.0,The libdd-capabilities Authors
+libdd-capabilities-impl,https://github.com/DataDog/libdatadog/tree/main/libdd-capabilities-impl,Apache-2.0,The libdd-capabilities-impl Authors
 libdd-common,https://github.com/DataDog/libdatadog/tree/main/datadog-common,Apache-2.0,The libdd-common Authors
 libdd-data-pipeline,https://github.com/DataDog/libdatadog/tree/main/libdd-data-pipeline,Apache-2.0,The libdd-data-pipeline Authors
 libdd-ddsketch,https://github.com/DataDog/libdatadog/tree/main/libdd-ddsketch,Apache-2.0,The libdd-ddsketch Authors
@@ -128,7 +124,6 @@ libdd-trace-obfuscation,https://github.com/DataDog/libdatadog/tree/main/libdd-tr
 libdd-trace-protobuf,https://github.com/DataDog/libdatadog/tree/main/libdd-trace-protobuf,Apache-2.0,The libdd-trace-protobuf Authors
 libdd-trace-stats,https://github.com/DataDog/libdatadog/tree/main/libdd-trace-stats,Apache-2.0,The libdd-trace-stats Authors
 libdd-trace-utils,https://github.com/DataDog/libdatadog/tree/main/libdd-trace-utils,Apache-2.0,The libdd-trace-utils Authors
-libloading,https://github.com/nagisa/rust_libloading,ISC,Simonas Kazlauskas <libloading@kazlauskas.me>
 linux-raw-sys,https://github.com/sunfishcode/linux-raw-sys,Apache-2.0 WITH LLVM-exception OR Apache-2.0 OR MIT,Dan Gohman <dev@sunfishcode.online>
 litemap,https://github.com/unicode-org/icu4x,Unicode-3.0,The ICU4X Project Developers
 lock_api,https://github.com/Amanieu/parking_lot,MIT OR Apache-2.0,Amanieu d'Antras <amanieu@gmail.com>
@@ -138,16 +133,14 @@ lru-slab,https://github.com/Ralith/lru-slab,MIT OR Apache-2.0 OR Zlib,Benjamin S
 matchers,https://github.com/hawkw/matchers,MIT,Eliza Weisman <eliza@buoyant.io>
 memchr,https://github.com/BurntSushi/memchr,Unlicense OR MIT,"Andrew Gallant <jamslam@gmail.com>, bluss"
 mime,https://github.com/hyperium/mime,MIT OR Apache-2.0,Sean McArthur <sean@seanmonstar.com>
-minimal-lexical,https://github.com/Alexhuszagh/minimal-lexical,MIT OR Apache-2.0,Alex Huszagh <ahuszagh@gmail.com>
 miniz_oxide,https://github.com/Frommi/miniz_oxide/tree/master/miniz_oxide,MIT OR Zlib OR Apache-2.0,"Frommi <daniil.liferenko@gmail.com>, oyvindln <oyvindln@users.noreply.github.com>, Rich Geldreich richgel99@gmail.com"
 mio,https://github.com/tokio-rs/mio,MIT,"Carl Lerche <me@carllerche.com>, Thomas de Zeeuw <thomasdezeeuw@gmail.com>, Tokio Contributors <team@tokio.rs>"
 multimap,https://github.com/havarnov/multimap,MIT OR Apache-2.0,Håvar Nøvik <havar.novik@gmail.com>
 nix,https://github.com/nix-rust/nix,MIT,The nix-rust Project Developers
-nom,https://github.com/Geal/nom,MIT,contact@geoffroycouprie.com
 nu-ansi-term,https://github.com/nushell/nu-ansi-term,MIT,"ogham@bsago.me, Ryan Scheel (Havvy) <ryan.havvy@gmail.com>, Josh Triplett <josh@joshtriplett.org>, The Nushell Project Developers"
 num-traits,https://github.com/rust-num/num-traits,MIT OR Apache-2.0,The Rust Project Developers
 once_cell,https://github.com/matklad/once_cell,MIT OR Apache-2.0,Aleksey Kladov <aleksey.kladov@gmail.com>
-openssl-probe,https://github.com/rustls/openssl-probe,MIT OR Apache-2.0,Alex Crichton <alex@alexcrichton.com>
+openssl-probe,https://github.com/alexcrichton/openssl-probe,MIT OR Apache-2.0,Alex Crichton <alex@alexcrichton.com>
 opentelemetry,https://github.com/open-telemetry/opentelemetry-rust/tree/main/opentelemetry,Apache-2.0,The opentelemetry Authors
 opentelemetry-semantic-conventions,https://github.com/open-telemetry/opentelemetry-rust/tree/main/opentelemetry-semantic-conventions,Apache-2.0,The opentelemetry-semantic-conventions Authors
 opentelemetry_sdk,https://github.com/open-telemetry/opentelemetry-rust/tree/main/opentelemetry-sdk,Apache-2.0,The opentelemetry_sdk Authors

--- a/LICENSE-3rdparty.csv
+++ b/LICENSE-3rdparty.csv
@@ -11,6 +11,9 @@ async-object-pool,https://github.com/alexliesenfeld/async-object-pool,MIT,Alexan
 async-trait,https://github.com/dtolnay/async-trait,MIT OR Apache-2.0,David Tolnay <dtolnay@gmail.com>
 atomic,https://github.com/Amanieu/atomic-rs,Apache-2.0 OR MIT,Amanieu d'Antras <amanieu@gmail.com>
 atomic-waker,https://github.com/smol-rs/atomic-waker,Apache-2.0 OR MIT,"Stjepan Glavina <stjepang@gmail.com>, Contributors to futures-rs"
+aws-lc-fips-sys,https://github.com/aws/aws-lc-rs,ISC AND (Apache-2.0 OR ISC) AND OpenSSL,AWS-LC
+aws-lc-rs,https://github.com/aws/aws-lc-rs,ISC AND (Apache-2.0 OR ISC),AWS-LibCrypto
+aws-lc-sys,https://github.com/aws/aws-lc-rs,ISC AND (Apache-2.0 OR ISC) AND Apache-2.0 AND MIT AND BSD-3-Clause AND (Apache-2.0 OR ISC OR MIT) AND (Apache-2.0 OR ISC OR MIT-0),AWS-LC
 base64,https://github.com/marshallpierce/rust-base64,MIT OR Apache-2.0,"Alice Maz <alice@alicemaz.com>, Marshall Pierce <marshall@mpierce.org>"
 base64,https://github.com/marshallpierce/rust-base64,MIT OR Apache-2.0,Marshall Pierce <marshall@mpierce.org>
 bit-set,https://github.com/contain-rs/bit-set,Apache-2.0 OR MIT,Alexis Beingessner <a.beingessner@gmail.com>
@@ -27,7 +30,9 @@ camino,https://github.com/camino-rs/camino,MIT OR Apache-2.0,"Without Boats <sao
 cargo-platform,https://github.com/rust-lang/cargo,MIT OR Apache-2.0,The cargo-platform Authors
 cargo_metadata,https://github.com/oli-obk/cargo_metadata,MIT,Oliver Schneider <git-spam-no-reply9815368754983@oli-obk.de>
 cc,https://github.com/rust-lang/cc-rs,MIT OR Apache-2.0,Alex Crichton <alex@alexcrichton.com>
+cexpr,https://github.com/jethrogb/rust-cexpr,Apache-2.0 OR MIT,Jethro Beekman <jethro@jbeekman.nl>
 cfg-if,https://github.com/rust-lang/cfg-if,MIT OR Apache-2.0,Alex Crichton <alex@alexcrichton.com>
+clang-sys,https://github.com/KyleMayes/clang-sys,Apache-2.0,Kyle Mayes <kyle@mayeses.com>
 concurrent-queue,https://github.com/smol-rs/concurrent-queue,Apache-2.0 OR MIT,"Stjepan Glavina <stjepang@gmail.com>, Taiki Endo <te316e89@gmail.com>, John Nunley <dev@notgull.net>"
 const_format,https://github.com/rodrimati1992/const_format_crates,Zlib,rodrimati1992 <rodrimatt1985@gmail.com>
 const_format_proc_macros,https://github.com/rodrimati1992/const_format_crates,Zlib,rodrimati1992 <rodrimatt1985@gmail.com>
@@ -73,6 +78,7 @@ futures-timer,https://github.com/async-rs/futures-timer,MIT OR Apache-2.0,Alex C
 futures-util,https://github.com/rust-lang/futures-rs,MIT OR Apache-2.0,The futures-util Authors
 generic-array,https://github.com/fizyk20/generic-array,MIT,"Bartłomiej Kamiński <fizyk20@gmail.com>, Aaron Trent <novacrazy@gmail.com>"
 getrandom,https://github.com/rust-random/getrandom,MIT OR Apache-2.0,The Rand Project Developers
+glob,https://github.com/rust-lang/glob,MIT OR Apache-2.0,The Rust Project Developers
 h2,https://github.com/hyperium/h2,MIT,"Carl Lerche <me@carllerche.com>, Sean McArthur <sean@seanmonstar.com>"
 hashbrown,https://github.com/rust-lang/hashbrown,MIT OR Apache-2.0,Amanieu d'Antras <amanieu@gmail.com>
 headers,https://github.com/hyperium/headers,MIT,Sean McArthur <sean@seanmonstar.com>
@@ -124,6 +130,7 @@ libdd-trace-obfuscation,https://github.com/DataDog/libdatadog/tree/main/libdd-tr
 libdd-trace-protobuf,https://github.com/DataDog/libdatadog/tree/main/libdd-trace-protobuf,Apache-2.0,The libdd-trace-protobuf Authors
 libdd-trace-stats,https://github.com/DataDog/libdatadog/tree/main/libdd-trace-stats,Apache-2.0,The libdd-trace-stats Authors
 libdd-trace-utils,https://github.com/DataDog/libdatadog/tree/main/libdd-trace-utils,Apache-2.0,The libdd-trace-utils Authors
+libloading,https://github.com/nagisa/rust_libloading,ISC,Simonas Kazlauskas <libloading@kazlauskas.me>
 linux-raw-sys,https://github.com/sunfishcode/linux-raw-sys,Apache-2.0 WITH LLVM-exception OR Apache-2.0 OR MIT,Dan Gohman <dev@sunfishcode.online>
 litemap,https://github.com/unicode-org/icu4x,Unicode-3.0,The ICU4X Project Developers
 lock_api,https://github.com/Amanieu/parking_lot,MIT OR Apache-2.0,Amanieu d'Antras <amanieu@gmail.com>
@@ -133,10 +140,12 @@ lru-slab,https://github.com/Ralith/lru-slab,MIT OR Apache-2.0 OR Zlib,Benjamin S
 matchers,https://github.com/hawkw/matchers,MIT,Eliza Weisman <eliza@buoyant.io>
 memchr,https://github.com/BurntSushi/memchr,Unlicense OR MIT,"Andrew Gallant <jamslam@gmail.com>, bluss"
 mime,https://github.com/hyperium/mime,MIT OR Apache-2.0,Sean McArthur <sean@seanmonstar.com>
+minimal-lexical,https://github.com/Alexhuszagh/minimal-lexical,MIT OR Apache-2.0,Alex Huszagh <ahuszagh@gmail.com>
 miniz_oxide,https://github.com/Frommi/miniz_oxide/tree/master/miniz_oxide,MIT OR Zlib OR Apache-2.0,"Frommi <daniil.liferenko@gmail.com>, oyvindln <oyvindln@users.noreply.github.com>, Rich Geldreich richgel99@gmail.com"
 mio,https://github.com/tokio-rs/mio,MIT,"Carl Lerche <me@carllerche.com>, Thomas de Zeeuw <thomasdezeeuw@gmail.com>, Tokio Contributors <team@tokio.rs>"
 multimap,https://github.com/havarnov/multimap,MIT OR Apache-2.0,Håvar Nøvik <havar.novik@gmail.com>
 nix,https://github.com/nix-rust/nix,MIT,The nix-rust Project Developers
+nom,https://github.com/Geal/nom,MIT,contact@geoffroycouprie.com
 nu-ansi-term,https://github.com/nushell/nu-ansi-term,MIT,"ogham@bsago.me, Ryan Scheel (Havvy) <ryan.havvy@gmail.com>, Josh Triplett <josh@joshtriplett.org>, The Nushell Project Developers"
 num-traits,https://github.com/rust-num/num-traits,MIT OR Apache-2.0,The Rust Project Developers
 once_cell,https://github.com/matklad/once_cell,MIT OR Apache-2.0,Aleksey Kladov <aleksey.kladov@gmail.com>

--- a/crates/datadog-agent-config/Cargo.toml
+++ b/crates/datadog-agent-config/Cargo.toml
@@ -6,8 +6,8 @@ license.workspace = true
 
 [dependencies]
 figment = { version = "0.10", default-features = false, features = ["yaml", "env"] }
-libdd-trace-obfuscation = { git = "https://github.com/DataDog/libdatadog", rev = "8c88979985154d6d97c0fc2ca9039682981eacad" }
-libdd-trace-utils = { git = "https://github.com/DataDog/libdatadog", rev = "8c88979985154d6d97c0fc2ca9039682981eacad" }
+libdd-trace-obfuscation = { git = "https://github.com/DataDog/libdatadog", rev = "986aab55cb7941d8453dffb59d35a70599d08665" }
+libdd-trace-utils = { git = "https://github.com/DataDog/libdatadog", rev = "986aab55cb7941d8453dffb59d35a70599d08665" }
 log = { version = "0.4", default-features = false }
 serde = { version = "1.0", default-features = false, features = ["derive"] }
 serde-aux = { version = "4.7", default-features = false }

--- a/crates/datadog-fips/Cargo.toml
+++ b/crates/datadog-fips/Cargo.toml
@@ -9,7 +9,7 @@ repository.workspace = true
 [dependencies]
 reqwest = { version = "0.12.4", features = ["json", "http2"], default-features = false }
 rustls = { version = "0.23.18", default-features = false, features = ["fips"], optional = true }
-rustls-native-certs = { version = "0.8.1", optional = true }
+rustls-native-certs = { version = ">=0.8.1, <0.8.3", optional = true }
 tracing = { version = "0.1.40", default-features = false }
 
 [features]

--- a/crates/datadog-serverless-compat/Cargo.toml
+++ b/crates/datadog-serverless-compat/Cargo.toml
@@ -12,7 +12,7 @@ windows-pipes = ["datadog-trace-agent/windows-pipes", "dogstatsd/windows-pipes"]
 [dependencies]
 datadog-logs-agent = { path = "../datadog-logs-agent" }
 datadog-trace-agent = { path = "../datadog-trace-agent" }
-libdd-trace-utils = { git = "https://github.com/DataDog/libdatadog", rev = "8c88979985154d6d97c0fc2ca9039682981eacad" }
+libdd-trace-utils = { git = "https://github.com/DataDog/libdatadog", rev = "986aab55cb7941d8453dffb59d35a70599d08665" }
 datadog-fips = { path = "../datadog-fips", default-features = false }
 dogstatsd = { path = "../dogstatsd", default-features = true }
 reqwest = { version = "0.12.4", default-features = false }

--- a/crates/datadog-trace-agent/Cargo.toml
+++ b/crates/datadog-trace-agent/Cargo.toml
@@ -24,12 +24,12 @@ async-trait = "0.1.64"
 tracing = { version = "0.1", default-features = false }
 serde = { version = "1.0.145", features = ["derive"] }
 serde_json = "1.0"
-libdd-common = { git = "https://github.com/DataDog/libdatadog", rev = "8c88979985154d6d97c0fc2ca9039682981eacad" }
-libdd-trace-protobuf = { git = "https://github.com/DataDog/libdatadog", rev = "8c88979985154d6d97c0fc2ca9039682981eacad" }
-libdd-trace-utils = { git = "https://github.com/DataDog/libdatadog", rev = "8c88979985154d6d97c0fc2ca9039682981eacad", features = [
+libdd-common = { git = "https://github.com/DataDog/libdatadog", rev = "986aab55cb7941d8453dffb59d35a70599d08665" }
+libdd-trace-protobuf = { git = "https://github.com/DataDog/libdatadog", rev = "986aab55cb7941d8453dffb59d35a70599d08665" }
+libdd-trace-utils = { git = "https://github.com/DataDog/libdatadog", rev = "986aab55cb7941d8453dffb59d35a70599d08665", features = [
     "mini_agent",
 ] }
-libdd-trace-obfuscation = { git = "https://github.com/DataDog/libdatadog", rev = "8c88979985154d6d97c0fc2ca9039682981eacad" }
+libdd-trace-obfuscation = { git = "https://github.com/DataDog/libdatadog", rev = "986aab55cb7941d8453dffb59d35a70599d08665" }
 datadog-fips = { path = "../datadog-fips" }
 reqwest = { version = "0.12.23", features = ["json", "http2"], default-features = false }
 bytes = "1.10.1"
@@ -40,6 +40,6 @@ serial_test = "2.0.0"
 duplicate = "2.0.1"
 temp-env = "0.3.6"
 tempfile = "3.3.0"
-libdd-trace-utils = { git = "https://github.com/DataDog/libdatadog", rev = "8c88979985154d6d97c0fc2ca9039682981eacad", features = [
+libdd-trace-utils = { git = "https://github.com/DataDog/libdatadog", rev = "986aab55cb7941d8453dffb59d35a70599d08665", features = [
     "test-utils",
 ] }

--- a/crates/datadog-trace-agent/Cargo.toml
+++ b/crates/datadog-trace-agent/Cargo.toml
@@ -24,6 +24,7 @@ async-trait = "0.1.64"
 tracing = { version = "0.1", default-features = false }
 serde = { version = "1.0.145", features = ["derive"] }
 serde_json = "1.0"
+libdd-capabilities = { git = "https://github.com/DataDog/libdatadog", rev = "986aab55cb7941d8453dffb59d35a70599d08665" }
 libdd-common = { git = "https://github.com/DataDog/libdatadog", rev = "986aab55cb7941d8453dffb59d35a70599d08665" }
 libdd-trace-protobuf = { git = "https://github.com/DataDog/libdatadog", rev = "986aab55cb7941d8453dffb59d35a70599d08665" }
 libdd-trace-utils = { git = "https://github.com/DataDog/libdatadog", rev = "986aab55cb7941d8453dffb59d35a70599d08665", features = [

--- a/crates/datadog-trace-agent/src/config.rs
+++ b/crates/datadog-trace-agent/src/config.rs
@@ -296,6 +296,7 @@ mod tests {
             [
                 ("DD_API_KEY", Some("_not_a_real_key_")),
                 ("K_SERVICE", Some("function_name")),
+                ("FUNCTION_TARGET", Some("function_target")),
             ],
             || {
                 let config_res = config::Config::new();
@@ -329,6 +330,7 @@ mod tests {
             [
                 ("DD_API_KEY", Some("_not_a_real_key_")),
                 ("K_SERVICE", Some("function_name")),
+                ("FUNCTION_TARGET", Some("function_target")),
                 ("DD_SITE", Some(dd_site)),
             ],
             || {
@@ -356,6 +358,7 @@ mod tests {
             [
                 ("DD_API_KEY", Some("_not_a_real_key_")),
                 ("K_SERVICE", Some("function_name")),
+                ("FUNCTION_TARGET", Some("function_target")),
                 ("DD_SITE", Some(dd_site)),
             ],
             || {
@@ -374,6 +377,7 @@ mod tests {
             [
                 ("DD_API_KEY", Some("_not_a_real_key_")),
                 ("K_SERVICE", Some("function_name")),
+                ("FUNCTION_TARGET", Some("function_target")),
                 ("DD_APM_DD_URL", Some("http://127.0.0.1:3333")),
             ],
             || {

--- a/crates/datadog-trace-agent/src/stats_flusher.rs
+++ b/crates/datadog-trace-agent/src/stats_flusher.rs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use async_trait::async_trait;
+use libdd_common::DefaultHttpClient;
 use std::{sync::Arc, time};
 use tokio::sync::{Mutex, mpsc::Receiver};
 use tracing::{debug, error};
@@ -76,7 +77,7 @@ impl StatsFlusher for ServerlessStatsFlusher {
         };
 
         #[allow(clippy::unwrap_used)]
-        match stats_utils::send_stats_payload(
+        match stats_utils::send_stats_payload::<DefaultHttpClient>(
             serialized_stats_payload,
             &config.trace_stats_intake,
             config.trace_stats_intake.api_key.as_ref().unwrap(),

--- a/crates/datadog-trace-agent/src/trace_flusher.rs
+++ b/crates/datadog-trace-agent/src/trace_flusher.rs
@@ -79,7 +79,7 @@ impl TraceFlusher for ServerlessTraceFlusher {
         }
         debug!("Flushing {} traces", traces.len());
 
-        let http_client = match ProxyHttpClient::try_new(self.config.proxy_url.as_ref()) {
+        let http_client = match ProxyHttpClient::with_proxy(self.config.proxy_url.as_ref()) {
             Ok(client) => client,
             Err(e) => {
                 error!("Failed to create HTTP client: {e:?}");
@@ -112,7 +112,9 @@ impl std::fmt::Debug for ProxyHttpClient {
 }
 
 impl ProxyHttpClient {
-    fn try_new(proxy_https: Option<&String>) -> Result<Self, Box<dyn Error>> {
+    // `HttpClientTrait::new_client` takes no arguments, so we use `with_proxy` to
+    // take in the proxy URL and build the client. `new_client` is never called on our code path.
+    fn with_proxy(proxy_https: Option<&String>) -> Result<Self, Box<dyn Error>> {
         if let Some(proxy) = proxy_https {
             let proxy =
                 hyper_http_proxy::Proxy::new(hyper_http_proxy::Intercept::Https, proxy.parse()?);
@@ -133,7 +135,7 @@ impl ProxyHttpClient {
 impl HttpClientTrait for ProxyHttpClient {
     #[allow(clippy::expect_used)]
     fn new_client() -> Self {
-        Self::try_new(None).expect("building proxy connector with default TLS should not fail")
+        Self::with_proxy(None).expect("building proxy connector with default TLS should not fail")
     }
 
     fn request(

--- a/crates/datadog-trace-agent/src/trace_flusher.rs
+++ b/crates/datadog-trace-agent/src/trace_flusher.rs
@@ -6,7 +6,11 @@ use std::{error::Error, sync::Arc, time};
 use tokio::sync::{Mutex, mpsc::Receiver};
 use tracing::{debug, error};
 
-use libdd_common::{GenericHttpClient, http_common};
+use http_body_util::BodyExt;
+use libdd_capabilities::http::{HttpClientTrait, HttpError};
+use libdd_capabilities::{MaybeSend, Request, Response};
+use libdd_common::connector::Connector;
+use libdd_common::http_common::{self, Body, GenericHttpClient};
 use libdd_trace_utils::trace_utils;
 use libdd_trace_utils::trace_utils::SendData;
 
@@ -75,14 +79,13 @@ impl TraceFlusher for ServerlessTraceFlusher {
         }
         debug!("Flushing {} traces", traces.len());
 
-        let http_client =
-            match ServerlessTraceFlusher::get_http_client(self.config.proxy_url.as_ref()) {
-                Ok(client) => client,
-                Err(e) => {
-                    error!("Failed to create HTTP client: {e:?}");
-                    return;
-                }
-            };
+        let http_client = match ProxyHttpClient::try_new(self.config.proxy_url.as_ref()) {
+            Ok(client) => client,
+            Err(e) => {
+                error!("Failed to create HTTP client: {e:?}");
+                return;
+            }
+        };
 
         // Retries are handled internally by SendData::send()
         for coalesced_traces in trace_utils::coalesce_send_data(traces) {
@@ -97,26 +100,61 @@ impl TraceFlusher for ServerlessTraceFlusher {
     }
 }
 
-impl ServerlessTraceFlusher {
-    fn get_http_client(
-        proxy_https: Option<&String>,
-    ) -> Result<
-        GenericHttpClient<hyper_http_proxy::ProxyConnector<libdd_common::connector::Connector>>,
-        Box<dyn Error>,
-    > {
+#[derive(Clone)]
+struct ProxyHttpClient {
+    client: GenericHttpClient<hyper_http_proxy::ProxyConnector<Connector>>,
+}
+
+impl std::fmt::Debug for ProxyHttpClient {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("ProxyHttpClient").finish()
+    }
+}
+
+impl ProxyHttpClient {
+    fn try_new(proxy_https: Option<&String>) -> Result<Self, Box<dyn Error>> {
         if let Some(proxy) = proxy_https {
             let proxy =
                 hyper_http_proxy::Proxy::new(hyper_http_proxy::Intercept::Https, proxy.parse()?);
-            let proxy_connector = hyper_http_proxy::ProxyConnector::from_proxy(
-                libdd_common::connector::Connector::default(),
-                proxy,
-            )?;
-            Ok(http_common::client_builder().build(proxy_connector))
+            let proxy_connector =
+                hyper_http_proxy::ProxyConnector::from_proxy(Connector::default(), proxy)?;
+            Ok(Self {
+                client: http_common::client_builder().build(proxy_connector),
+            })
         } else {
-            let proxy_connector = hyper_http_proxy::ProxyConnector::new(
-                libdd_common::connector::Connector::default(),
-            )?;
-            Ok(http_common::client_builder().build(proxy_connector))
+            let proxy_connector = hyper_http_proxy::ProxyConnector::new(Connector::default())?;
+            Ok(Self {
+                client: http_common::client_builder().build(proxy_connector),
+            })
+        }
+    }
+}
+
+impl HttpClientTrait for ProxyHttpClient {
+    #[allow(clippy::expect_used)]
+    fn new_client() -> Self {
+        Self::try_new(None).expect("building proxy connector with default TLS should not fail")
+    }
+
+    fn request(
+        &self,
+        req: Request<bytes::Bytes>,
+    ) -> impl std::future::Future<Output = Result<Response<bytes::Bytes>, HttpError>> + MaybeSend
+    {
+        let client = self.client.clone();
+        async move {
+            let hyper_req = req.map(Body::from_bytes);
+            let response = client
+                .request(hyper_req)
+                .await
+                .map_err(|e| HttpError::Network(e.into()))?;
+            let (parts, body) = response.into_parts();
+            let collected = body
+                .collect()
+                .await
+                .map_err(|e| HttpError::ResponseBody(e.into()))?
+                .to_bytes();
+            Ok(Response::from_parts(parts, collected))
         }
     }
 }


### PR DESCRIPTION
### What does this PR do?

- Update libdatadog rev to https://github.com/DataDog/libdatadog/commit/986aab55cb7941d8453dffb59d35a70599d08665
- Pins `rustls-native-certs` to <0.8.3 in datadog-fips to match the [new libdd-common constraint](https://github.com/DataDog/libdatadog/blob/04c735c2413facf904411464b54c0e6935fc00a1/libdd-common/Cargo.toml#L42) (libdd-common wants <0.8.3, datadog-fips was on ^0.8.1 which resolved to 0.8.3)
- Adapts `stats_flusher` and `trace_flusher` to the new `HttpClientTrait`-based `SendData::send` API and adds `libdd-capabilities` as a direct dependency of `datadog-trace-agent`. Needed as a result of https://github.com/DataDog/libdatadog/pull/1555

### Motivation
https://datadoghq.atlassian.net/browse/SVLS-8799 

https://github.com/DataDog/libdatadog/pull/1857 updates the agent's cloud environment detection logic to enable customers instrumenting their Azure Functions to set the `FUNCTION_NAME` environment variable. Previously, `FUNCTION_NAME` was used to identify a Google Cloud Run Function; this change makes the detection logic more specific by checking multiple cloud-specific env vars at once.

### Additional Notes
- https://github.com/DataDog/libdatadog/pull/1555 introduced a capability trait architecture (groundwork for WASM support). `SendData::send` is now generic over `H: HttpClientTrait` instead of `GenericHttpClient<C: Connect>`, so our flushers no longer compiled against the new rev.
    - **`stats_flusher`**: now uses`libdd_common::DefaultHttpClient`
    - **`trace_flusher`**: needs proxy support which `DefaultHttpClient` doesn't provide. Introduced a local `ProxyHttpClient` newtype that wraps `GenericHttpClient<ProxyConnector<Connector>>` and implements `HttpClientTrait`
      - The connector construction logic is unchanged and the `request()` body [mirrors libdatadog's own](https://github.com/DataDog/libdatadog/blob/04c735c2413facf904411464b54c0e6935fc00a1/libdd-common/src/http_common.rs#L328) `DefaultHttpClient::request`
- Updated rustls-webpki to address [this audit check](https://github.com/DataDog/serverless-components/actions/runs/24580796247/job/71877842283?pr=115)
- Added `FUNCTION_TARGET` alongside every `K_SERVICE` in `test_default_trace_and_trace_stats_urls` since `read_cloud_env` in libdatadog now requires both env vars to detect a Cloud Run Function when creating a Config

### Describe how to test/QA your changes

Deployed an Azure function and set the env var `FUNCTION_NAME`. Confirmed that traces continued to flow to Datadog