### PR TITLE
chore: fix cargo audit errors and warnings, cargo clippy warnings

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -89,7 +89,7 @@ checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -179,7 +179,7 @@ dependencies = [
  "regex",
  "rustc-hash",
  "shlex",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -509,7 +509,7 @@ dependencies = [
  "opentelemetry",
  "opentelemetry-semantic-conventions",
  "opentelemetry_sdk",
- "rand 0.8.5",
+ "rand 0.8.6",
  "rustc_version_runtime",
  "serde",
  "serde_json",
@@ -608,7 +608,7 @@ checksum = "cb7330aeadfbe296029522e6c40f315320aba36fc43a5b3632f3795348f3bd22"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
  "unicode-xid",
 ]
 
@@ -630,7 +630,7 @@ checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -668,12 +668,13 @@ checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
 
 [[package]]
 name = "duplicate"
-version = "0.4.1"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0a4be4cd710e92098de6ad258e6e7c24af11c29c5142f3c6f2a545652480ff8"
+checksum = "8e92f10a49176cbffacaedabfaa11d51db1ea0f80a83c26e1873b43cd1742c24"
 dependencies = [
- "heck 0.4.1",
- "proc-macro-error",
+ "heck",
+ "proc-macro2",
+ "proc-macro2-diagnostics",
 ]
 
 [[package]]
@@ -872,7 +873,7 @@ checksum = "e835b70203e41293343137df5c0664546da5745f82ec9b84d40be8336958447b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -1036,12 +1037,6 @@ checksum = "54b4a22553d4242c49fddb9ba998a99962b5cc6f22cb5a3482bec22522403ce4"
 dependencies = [
  "http",
 ]
-
-[[package]]
-name = "heck"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
 
 [[package]]
 name = "heck"
@@ -1678,7 +1673,7 @@ dependencies = [
  "libdd-trace-normalization 1.0.2",
  "libdd-trace-protobuf 2.0.0",
  "prost 0.14.3",
- "rand 0.8.5",
+ "rand 0.8.6",
  "rmp",
  "rmp-serde",
  "rmpv",
@@ -1710,7 +1705,7 @@ dependencies = [
  "libdd-trace-normalization 1.0.3",
  "libdd-trace-protobuf 3.0.0",
  "prost 0.14.3",
- "rand 0.8.5",
+ "rand 0.8.6",
  "rmp",
  "rmp-serde",
  "rmpv",
@@ -1844,7 +1839,7 @@ dependencies = [
  "hyper-util",
  "log",
  "pin-project-lite",
- "rand 0.9.2",
+ "rand 0.9.4",
  "regex",
  "serde_json",
  "serde_urlencoded",
@@ -1940,7 +1935,7 @@ dependencies = [
  "futures-util",
  "opentelemetry",
  "percent-encoding",
- "rand 0.9.2",
+ "rand 0.9.4",
  "thiserror 2.0.18",
 ]
 
@@ -2020,7 +2015,7 @@ dependencies = [
  "proc-macro2",
  "proc-macro2-diagnostics",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -2056,7 +2051,7 @@ checksum = "d9b20ed30f105399776b9c883e68e536ef602a16ae6f596d2c473591d6ad64c6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -2102,31 +2097,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
 dependencies = [
  "proc-macro2",
- "syn 2.0.117",
-]
-
-[[package]]
-name = "proc-macro-error"
-version = "1.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da25490ff9892aab3fcf7c36f08cfb902dd3e71ca0f9f9517bea02a73a5ce38c"
-dependencies = [
- "proc-macro-error-attr",
- "proc-macro2",
- "quote",
- "syn 1.0.109",
- "version_check",
-]
-
-[[package]]
-name = "proc-macro-error-attr"
-version = "1.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1be40180e52ecc98ad80b184934baf3d0d29f979574e439af5a55274b35f869"
-dependencies = [
- "proc-macro2",
- "quote",
- "version_check",
+ "syn",
 ]
 
 [[package]]
@@ -2146,7 +2117,7 @@ checksum = "af066a9c399a26e020ada66a034357a868728e72cd426f3adcd35f80d88d88c8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
  "version_check",
  "yansi",
 ]
@@ -2161,7 +2132,7 @@ dependencies = [
  "bit-vec",
  "bitflags",
  "num-traits",
- "rand 0.9.2",
+ "rand 0.9.4",
  "rand_chacha 0.9.0",
  "rand_xorshift",
  "regex-syntax",
@@ -2196,7 +2167,7 @@ version = "0.13.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be769465445e8c1474e9c5dac2018218498557af32d9ed057325ec9a41ae81bf"
 dependencies = [
- "heck 0.5.0",
+ "heck",
  "itertools 0.14.0",
  "log",
  "multimap",
@@ -2206,7 +2177,7 @@ dependencies = [
  "prost 0.13.5",
  "prost-types",
  "regex",
- "syn 2.0.117",
+ "syn",
  "tempfile",
 ]
 
@@ -2220,7 +2191,7 @@ dependencies = [
  "itertools 0.14.0",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -2233,7 +2204,7 @@ dependencies = [
  "itertools 0.14.0",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -2332,7 +2303,7 @@ dependencies = [
  "bytes",
  "getrandom 0.3.4",
  "lru-slab",
- "rand 0.9.2",
+ "rand 0.9.4",
  "ring",
  "rustc-hash",
  "rustls",
@@ -2381,9 +2352,9 @@ checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "rand"
-version = "0.8.5"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
+checksum = "5ca0ecfa931c29007047d1bc58e623ab12e5590e8c7cc53200d5202b69266d8a"
 dependencies = [
  "libc",
  "rand_chacha 0.3.1",
@@ -2392,9 +2363,9 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.9.2"
+version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
+checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
 dependencies = [
  "rand_chacha 0.9.0",
  "rand_core 0.9.5",
@@ -2473,7 +2444,7 @@ checksum = "b7186006dcb21920990093f30e3dea63b7d6e977bf1256be20c3563a5db070da"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -2676,9 +2647,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.10"
+version = "0.103.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df33b2b81ac578cabaf06b89b0631153a3f416b0a886e8a7a1707fb51abbd1ef"
+checksum = "8279bb85272c9f10811ae6a6c547ff594d6a7f3c6c6b02ee9726d1d0dcfcdd06"
 dependencies = [
  "aws-lc-rs",
  "ring",
@@ -2816,7 +2787,7 @@ checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -2890,7 +2861,7 @@ checksum = "91d129178576168c589c9ec973feedf7d3126c01ac2bf08795109aa35b69fb8f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -3000,16 +2971,6 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "syn"
-version = "1.0.109"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
-dependencies = [
- "proc-macro2",
- "unicode-ident",
-]
-
-[[package]]
-name = "syn"
 version = "2.0.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e665b8803e7b1d2a727f4023456bbbbe74da67099c585258af0ad9c5013b9b99"
@@ -3036,7 +2997,7 @@ checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -3106,7 +3067,7 @@ checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -3117,7 +3078,7 @@ checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -3178,7 +3139,7 @@ checksum = "5c55a2eff8b69ce66c84f85e1da1c233edc36ceb85a2058d11b0d6a3c7e7569c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -3247,7 +3208,7 @@ dependencies = [
  "prost-build",
  "prost-types",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -3315,7 +3276,7 @@ checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -3375,7 +3336,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ad06847b7afb65c7866a36664b75c40b895e318cea4f71299f013fb22965329d"
 dependencies = [
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -3582,7 +3543,7 @@ dependencies = [
  "bumpalo",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
  "wasm-bindgen-shared",
 ]
 
@@ -3941,7 +3902,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ea61de684c3ea68cb082b7a88508a8b27fcc8b797d738bfc99a82facf1d752dc"
 dependencies = [
  "anyhow",
- "heck 0.5.0",
+ "heck",
  "wit-parser",
 ]
 
@@ -3952,10 +3913,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
 dependencies = [
  "anyhow",
- "heck 0.5.0",
+ "heck",
  "indexmap",
  "prettyplease",
- "syn 2.0.117",
+ "syn",
  "wasm-metadata",
  "wit-bindgen-core",
  "wit-component",
@@ -3971,7 +3932,7 @@ dependencies = [
  "prettyplease",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
  "wit-bindgen-core",
  "wit-bindgen-rust",
 ]
@@ -4044,7 +4005,7 @@ checksum = "b659052874eb698efe5b9e8cf382204678a0086ebf46982b79d6ca3182927e5d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
  "synstructure",
 ]
 
@@ -4065,7 +4026,7 @@ checksum = "0e8bc7269b54418e7aeeef514aa68f8690b8c0489a06b0136e5f57c4c5ccab89"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -4085,7 +4046,7 @@ checksum = "d71e5d6e06ab090c67b5e44993ec16b72dcbaabc526db883a360057678b48502"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
  "synstructure",
 ]
 
@@ -4125,7 +4086,7 @@ checksum = "eadce39539ca5cb3985590102671f2567e659fca9666581ad3411d59207951f3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]

--- a/LICENSE-3rdparty.csv
+++ b/LICENSE-3rdparty.csv
@@ -84,7 +84,6 @@ hashbrown,https://github.com/rust-lang/hashbrown,MIT OR Apache-2.0,Amanieu d'Ant
 headers,https://github.com/hyperium/headers,MIT,Sean McArthur <sean@seanmonstar.com>
 headers-core,https://github.com/hyperium/headers,MIT,Sean McArthur <sean@seanmonstar.com>
 heck,https://github.com/withoutboats/heck,MIT OR Apache-2.0,The heck Authors
-heck,https://github.com/withoutboats/heck,MIT OR Apache-2.0,Without Boats <woboats@gmail.com>
 hex,https://github.com/KokaKiwi/rust-hex,MIT OR Apache-2.0,KokaKiwi <kokakiwi@kokakiwi.net>
 home,https://github.com/rust-lang/cargo,MIT OR Apache-2.0,Brian Anderson <andersrb@gmail.com>
 http,https://github.com/hyperium/http,MIT OR Apache-2.0,"Alex Crichton <alex@alexcrichton.com>, Carl Lerche <me@carllerche.com>, Sean McArthur <sean@seanmonstar.com>"
@@ -168,8 +167,6 @@ pin-utils,https://github.com/rust-lang-nursery/pin-utils,MIT OR Apache-2.0,Josef
 potential_utf,https://github.com/unicode-org/icu4x,Unicode-3.0,The ICU4X Project Developers
 ppv-lite86,https://github.com/cryptocorrosion/cryptocorrosion,MIT OR Apache-2.0,The CryptoCorrosion Contributors
 prettyplease,https://github.com/dtolnay/prettyplease,MIT OR Apache-2.0,David Tolnay <dtolnay@gmail.com>
-proc-macro-error,https://gitlab.com/CreepySkeleton/proc-macro-error,MIT OR Apache-2.0,CreepySkeleton <creepy-skeleton@yandex.ru>
-proc-macro-error-attr,https://gitlab.com/CreepySkeleton/proc-macro-error,MIT OR Apache-2.0,CreepySkeleton <creepy-skeleton@yandex.ru>
 proc-macro2,https://github.com/dtolnay/proc-macro2,MIT OR Apache-2.0,"David Tolnay <dtolnay@gmail.com>, Alex Crichton <alex@alexcrichton.com>"
 proc-macro2-diagnostics,https://github.com/SergioBenitez/proc-macro2-diagnostics,MIT OR Apache-2.0,Sergio Benitez <sb@sergio.bz>
 prost,https://github.com/tokio-rs/prost,Apache-2.0,"Dan Burkert <dan@danburkert.com>, Lucio Franco <luciofranco14@gmail.com>, Casper Meijn <casper@meijn.net>, Tokio Contributors <team@tokio.rs>"

--- a/crates/datadog-trace-agent/Cargo.toml
+++ b/crates/datadog-trace-agent/Cargo.toml
@@ -37,7 +37,7 @@ bytes = "1.10.1"
 [dev-dependencies]
 rmp-serde = "1.1.1"
 serial_test = "2.0.0"
-duplicate = "0.4.1"
+duplicate = "2.0.1"
 temp-env = "0.3.6"
 tempfile = "3.3.0"
 libdd-trace-utils = { git = "https://github.com/DataDog/libdatadog", rev = "8c88979985154d6d97c0fc2ca9039682981eacad", features = [

--- a/crates/datadog-trace-agent/src/mini_agent.rs
+++ b/crates/datadog-trace-agent/src/mini_agent.rs
@@ -192,13 +192,14 @@ impl MiniAgent {
                 // SAFETY: LAMBDA_LITE_SENTINEL_PATH is a hard-coded absolute path,
                 // so .parent() always returns Some.
                 if let Some(parent) = sentinel.parent()
-                    && let Err(e) = tokio::fs::create_dir_all(parent).await {
-                        error!(
-                            "Could not create parent directory for Lambda Lite sentinel \
+                    && let Err(e) = tokio::fs::create_dir_all(parent).await
+                {
+                    error!(
+                        "Could not create parent directory for Lambda Lite sentinel \
                              file at {}: {}.",
-                            LAMBDA_LITE_SENTINEL_PATH, e
-                        );
-                    }
+                        LAMBDA_LITE_SENTINEL_PATH, e
+                    );
+                }
                 if let Err(e) = tokio::fs::write(sentinel, b"").await {
                     error!(
                         "Could not write Lambda Lite sentinel file at {}: {}. \

--- a/crates/datadog-trace-agent/src/mini_agent.rs
+++ b/crates/datadog-trace-agent/src/mini_agent.rs
@@ -11,7 +11,7 @@ use std::net::SocketAddr;
 use std::sync::Arc;
 use std::time::Instant;
 use tokio::sync::mpsc::{self, Receiver, Sender};
-use tracing::{debug, error, warn};
+use tracing::{debug, error};
 
 use crate::http_utils::{log_and_create_http_response, verify_request_content_length};
 use crate::proxy_flusher::{ProxyFlusher, ProxyRequest};
@@ -191,15 +191,14 @@ impl MiniAgent {
                 let sentinel = std::path::Path::new(LAMBDA_LITE_SENTINEL_PATH);
                 // SAFETY: LAMBDA_LITE_SENTINEL_PATH is a hard-coded absolute path,
                 // so .parent() always returns Some.
-                if let Some(parent) = sentinel.parent() {
-                    if let Err(e) = tokio::fs::create_dir_all(parent).await {
+                if let Some(parent) = sentinel.parent()
+                    && let Err(e) = tokio::fs::create_dir_all(parent).await {
                         error!(
                             "Could not create parent directory for Lambda Lite sentinel \
                              file at {}: {}.",
                             LAMBDA_LITE_SENTINEL_PATH, e
                         );
                     }
-                }
                 if let Err(e) = tokio::fs::write(sentinel, b"").await {
                     error!(
                         "Could not write Lambda Lite sentinel file at {}: {}. \


### PR DESCRIPTION
### What does this PR do?

- Updates dependencies raised by cargo audit
- Fix cargo clippy warnings

### Motivation

cargo audit

```
Crate:     rustls-webpki
Version:   0.103.10
Title:     Name constraints for URI names were incorrectly accepted
Date:      2026-04-14
ID:        RUSTSEC-2026-0098
URL:       https://rustsec.org/advisories/RUSTSEC-2026-0098
Solution:  Upgrade to >=0.103.12, <0.104.0-alpha.1 OR >=0.104.0-alpha.6
Dependency tree:
rustls-webpki 0.103.10
└── rustls 0.23.37
    ├── tokio-rustls 0.26.4
    │   ├── reqwest 0.12.28
    │   │   ├── dogstatsd 0.1.0
    │   │   │   ├── datadog-serverless-compat 0.1.0
    │   │   │   └── datadog-agent-config 0.1.0
    │   │   ├── datadog-trace-agent 0.1.0
    │   │   │   └── datadog-serverless-compat 0.1.0
    │   │   ├── datadog-serverless-compat 0.1.0
    │   │   ├── datadog-logs-agent 0.1.0
    │   │   │   └── datadog-serverless-compat 0.1.0
    │   │   └── datadog-fips 0.1.0
    │   │       ├── datadog-trace-agent 0.1.0
    │   │       ├── datadog-serverless-compat 0.1.0
    │   │       └── datadog-logs-agent 0.1.0
    │   ├── libdd-common 3.0.1
    │   │   ├── libdd-trace-utils 3.0.0
    │   │   │   ├── libdd-trace-obfuscation 1.0.1
    │   │   │   │   ├── datadog-trace-agent 0.1.0
    │   │   │   │   └── datadog-agent-config 0.1.0
    │   │   │   ├── datadog-trace-agent 0.1.0
    │   │   │   ├── datadog-serverless-compat 0.1.0
    │   │   │   └── datadog-agent-config 0.1.0
    │   │   ├── libdd-trace-obfuscation 1.0.1
    │   │   └── datadog-trace-agent 0.1.0
    │   ├── hyper-rustls 0.27.7
    │   │   ├── reqwest 0.12.28
    │   │   ├── libdd-common 3.0.1
    │   │   └── hyper-http-proxy 1.1.0
    │   │       └── datadog-trace-agent 0.1.0
    │   └── hyper-http-proxy 1.1.0
    ├── reqwest 0.12.28
    ├── quinn-proto 0.11.14
    │   └── quinn 0.11.9
    │       └── reqwest 0.12.28
    ├── quinn 0.11.9
    ├── libdd-common 3.0.1
    ├── hyper-rustls 0.27.7
    └── datadog-fips 0.1.0

Crate:     rustls-webpki
Version:   0.103.10
Title:     Name constraints were accepted for certificates asserting a wildcard name
Date:      2026-04-14
ID:        RUSTSEC-2026-0099
URL:       https://rustsec.org/advisories/RUSTSEC-2026-0099
Solution:  Upgrade to >=0.103.12, <0.104.0-alpha.1 OR >=0.104.0-alpha.6

Crate:     proc-macro-error
Version:   1.0.4
Warning:   unmaintained
Title:     proc-macro-error is unmaintained
Date:      2024-09-01
ID:        RUSTSEC-2024-0370
URL:       https://rustsec.org/advisories/RUSTSEC-2024-0370
Dependency tree:
proc-macro-error 1.0.4
└── duplicate 0.4.1
    └── datadog-trace-agent 0.1.0
        └── datadog-serverless-compat 0.1.0

Crate:     rand
Version:   0.8.5
Warning:   unsound
Title:     Rand is unsound with a custom logger using `rand::rng()`
Date:      2026-04-09
ID:        RUSTSEC-2026-0097
URL:       https://rustsec.org/advisories/RUSTSEC-2026-0097
Dependency tree:
rand 0.8.5
├── libdd-trace-utils 3.0.0
│   ├── libdd-trace-obfuscation 1.0.1
│   │   ├── datadog-trace-agent 0.1.0
│   │   │   └── datadog-serverless-compat 0.1.0
│   │   └── datadog-agent-config 0.1.0
│   ├── datadog-trace-agent 0.1.0
│   ├── datadog-serverless-compat 0.1.0
│   └── datadog-agent-config 0.1.0
├── libdd-trace-utils 2.0.2
│   ├── libdd-trace-stats 1.0.3
│   │   └── libdd-data-pipeline 2.0.1
│   │       └── datadog-opentelemetry 0.3.0
│   │           └── datadog-agent-config 0.1.0
│   ├── libdd-data-pipeline 2.0.1
│   └── datadog-opentelemetry 0.3.0
└── datadog-opentelemetry 0.3.0

Crate:     rand
Version:   0.9.2
Warning:   unsound
Title:     Rand is unsound with a custom logger using `rand::rng()`
Date:      2026-04-09
ID:        RUSTSEC-2026-0097
URL:       https://rustsec.org/advisories/RUSTSEC-2026-0097
Dependency tree:
rand 0.9.2
├── quinn-proto 0.11.14
│   └── quinn 0.11.9
│       └── reqwest 0.12.28
│           ├── dogstatsd 0.1.0
│           │   ├── datadog-serverless-compat 0.1.0
│           │   └── datadog-agent-config 0.1.0
│           ├── datadog-trace-agent 0.1.0
│           │   └── datadog-serverless-compat 0.1.0
│           ├── datadog-serverless-compat 0.1.0
│           ├── datadog-logs-agent 0.1.0
│           │   └── datadog-serverless-compat 0.1.0
│           └── datadog-fips 0.1.0
│               ├── datadog-trace-agent 0.1.0
│               ├── datadog-serverless-compat 0.1.0
│               └── datadog-logs-agent 0.1.0
├── proptest 1.11.0
│   └── dogstatsd 0.1.0
├── opentelemetry_sdk 0.31.0
│   └── datadog-opentelemetry 0.3.0
│       └── datadog-agent-config 0.1.0
└── mockito 1.7.2
    ├── dogstatsd 0.1.0
    └── datadog-logs-agent 0.1.0

error: 2 vulnerabilities found!
warning: 3 allowed warnings found
```

cargo clippy

```
warning: unused import: `warn`
  --> crates/datadog-trace-agent/src/mini_agent.rs:14:29
   |
14 | use tracing::{debug, error, warn};
   |                             ^^^^
   |
   = note: `#[warn(unused_imports)]` (part of `#[warn(unused)]`) on by default

warning: this `if` statement can be collapsed
   --> crates/datadog-trace-agent/src/mini_agent.rs:194:17
    |
194 | /                 if let Some(parent) = sentinel.parent() {
195 | |                     if let Err(e) = tokio::fs::create_dir_all(parent).await {
196 | |                         error!(
197 | |                             "Could not create parent directory for Lambda Lite sentinel \
...   |
202 | |                 }
    | |_________________^
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/rust-1.91.0/index.html#collapsible_if
    = note: `#[warn(clippy::collapsible_if)]` on by default
help: collapse nested if block
    |
194 ~                 if let Some(parent) = sentinel.parent()
195 ~                     && let Err(e) = tokio::fs::create_dir_all(parent).await {
196 |                         error!(
...
200 |                         );
201 ~                     }
    |

warning: `datadog-trace-agent` (lib) generated 2 warnings (run `cargo clippy --fix --lib -p datadog-trace-agent` to apply 2 suggestions)
```

### Additional Notes

<!-- Any other relevant context that would be helpful. -->

### Describe how to test/QA your changes

Unit and integration tests
