### PR TITLE
feat: pass span_kinds_stats_computed and peer_tags to span concentrator

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -571,6 +571,7 @@ dependencies = [
  "bytes",
  "datadog-fips",
  "duplicate",
+ "flate2",
  "http-body-util",
  "hyper",
  "hyper-http-proxy",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1445,7 +1445,7 @@ checksum = "b5b646652bf6661599e1da8901b3b9522896f01e736bad5f723fe7a3a27f899d"
 [[package]]
 name = "libdd-capabilities"
 version = "1.0.0"
-source = "git+https://github.com/DataDog/libdatadog?rev=db05e1f8408a76075efb37ecec544d2e74217e57#db05e1f8408a76075efb37ecec544d2e74217e57"
+source = "git+https://github.com/DataDog/libdatadog?rev=4ae8ebe252451374c292efd159ce254c3f5a72e0#4ae8ebe252451374c292efd159ce254c3f5a72e0"
 dependencies = [
  "anyhow",
  "bytes",
@@ -1456,7 +1456,7 @@ dependencies = [
 [[package]]
 name = "libdd-capabilities-impl"
 version = "1.0.0"
-source = "git+https://github.com/DataDog/libdatadog?rev=db05e1f8408a76075efb37ecec544d2e74217e57#db05e1f8408a76075efb37ecec544d2e74217e57"
+source = "git+https://github.com/DataDog/libdatadog?rev=4ae8ebe252451374c292efd159ce254c3f5a72e0#4ae8ebe252451374c292efd159ce254c3f5a72e0"
 dependencies = [
  "bytes",
  "http",
@@ -1499,7 +1499,7 @@ dependencies = [
 [[package]]
 name = "libdd-common"
 version = "4.0.0"
-source = "git+https://github.com/DataDog/libdatadog?rev=db05e1f8408a76075efb37ecec544d2e74217e57#db05e1f8408a76075efb37ecec544d2e74217e57"
+source = "git+https://github.com/DataDog/libdatadog?rev=4ae8ebe252451374c292efd159ce254c3f5a72e0#4ae8ebe252451374c292efd159ce254c3f5a72e0"
 dependencies = [
  "anyhow",
  "bytes",
@@ -1572,7 +1572,7 @@ dependencies = [
 [[package]]
 name = "libdd-ddsketch"
 version = "1.0.1"
-source = "git+https://github.com/DataDog/libdatadog?rev=db05e1f8408a76075efb37ecec544d2e74217e57#db05e1f8408a76075efb37ecec544d2e74217e57"
+source = "git+https://github.com/DataDog/libdatadog?rev=4ae8ebe252451374c292efd159ce254c3f5a72e0#4ae8ebe252451374c292efd159ce254c3f5a72e0"
 dependencies = [
  "prost 0.14.3",
 ]
@@ -1594,7 +1594,7 @@ dependencies = [
 [[package]]
 name = "libdd-library-config"
 version = "1.1.0"
-source = "git+https://github.com/DataDog/libdatadog?rev=db05e1f8408a76075efb37ecec544d2e74217e57#db05e1f8408a76075efb37ecec544d2e74217e57"
+source = "git+https://github.com/DataDog/libdatadog?rev=4ae8ebe252451374c292efd159ce254c3f5a72e0#4ae8ebe252451374c292efd159ce254c3f5a72e0"
 dependencies = [
  "anyhow",
  "libc",
@@ -1611,7 +1611,7 @@ dependencies = [
 [[package]]
 name = "libdd-shared-runtime"
 version = "0.1.0"
-source = "git+https://github.com/DataDog/libdatadog?rev=db05e1f8408a76075efb37ecec544d2e74217e57#db05e1f8408a76075efb37ecec544d2e74217e57"
+source = "git+https://github.com/DataDog/libdatadog?rev=4ae8ebe252451374c292efd159ce254c3f5a72e0#4ae8ebe252451374c292efd159ce254c3f5a72e0"
 dependencies = [
  "async-trait",
  "futures",
@@ -1659,7 +1659,7 @@ dependencies = [
 [[package]]
 name = "libdd-tinybytes"
 version = "1.1.0"
-source = "git+https://github.com/DataDog/libdatadog?rev=db05e1f8408a76075efb37ecec544d2e74217e57#db05e1f8408a76075efb37ecec544d2e74217e57"
+source = "git+https://github.com/DataDog/libdatadog?rev=4ae8ebe252451374c292efd159ce254c3f5a72e0#4ae8ebe252451374c292efd159ce254c3f5a72e0"
 dependencies = [
  "serde",
 ]
@@ -1677,7 +1677,7 @@ dependencies = [
 [[package]]
 name = "libdd-trace-normalization"
 version = "2.0.0"
-source = "git+https://github.com/DataDog/libdatadog?rev=db05e1f8408a76075efb37ecec544d2e74217e57#db05e1f8408a76075efb37ecec544d2e74217e57"
+source = "git+https://github.com/DataDog/libdatadog?rev=4ae8ebe252451374c292efd159ce254c3f5a72e0#4ae8ebe252451374c292efd159ce254c3f5a72e0"
 dependencies = [
  "anyhow",
  "libdd-trace-protobuf 3.0.1",
@@ -1686,7 +1686,7 @@ dependencies = [
 [[package]]
 name = "libdd-trace-obfuscation"
 version = "2.0.0"
-source = "git+https://github.com/DataDog/libdatadog?rev=db05e1f8408a76075efb37ecec544d2e74217e57#db05e1f8408a76075efb37ecec544d2e74217e57"
+source = "git+https://github.com/DataDog/libdatadog?rev=4ae8ebe252451374c292efd159ce254c3f5a72e0#4ae8ebe252451374c292efd159ce254c3f5a72e0"
 dependencies = [
  "anyhow",
  "fluent-uri",
@@ -1695,7 +1695,6 @@ dependencies = [
  "libdd-trace-utils 3.0.1",
  "log",
  "percent-encoding",
- "regex",
  "serde",
  "serde_json",
 ]
@@ -1714,7 +1713,7 @@ dependencies = [
 [[package]]
 name = "libdd-trace-protobuf"
 version = "3.0.1"
-source = "git+https://github.com/DataDog/libdatadog?rev=db05e1f8408a76075efb37ecec544d2e74217e57#db05e1f8408a76075efb37ecec544d2e74217e57"
+source = "git+https://github.com/DataDog/libdatadog?rev=4ae8ebe252451374c292efd159ce254c3f5a72e0#4ae8ebe252451374c292efd159ce254c3f5a72e0"
 dependencies = [
  "prost 0.14.3",
  "serde",
@@ -1736,7 +1735,7 @@ dependencies = [
 [[package]]
 name = "libdd-trace-stats"
 version = "2.0.0"
-source = "git+https://github.com/DataDog/libdatadog?rev=db05e1f8408a76075efb37ecec544d2e74217e57#db05e1f8408a76075efb37ecec544d2e74217e57"
+source = "git+https://github.com/DataDog/libdatadog?rev=4ae8ebe252451374c292efd159ce254c3f5a72e0#4ae8ebe252451374c292efd159ce254c3f5a72e0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1745,8 +1744,9 @@ dependencies = [
  "libdd-capabilities",
  "libdd-capabilities-impl",
  "libdd-common 4.0.0",
- "libdd-ddsketch 1.0.1 (git+https://github.com/DataDog/libdatadog?rev=db05e1f8408a76075efb37ecec544d2e74217e57)",
+ "libdd-ddsketch 1.0.1 (git+https://github.com/DataDog/libdatadog?rev=4ae8ebe252451374c292efd159ce254c3f5a72e0)",
  "libdd-shared-runtime",
+ "libdd-trace-obfuscation",
  "libdd-trace-protobuf 3.0.1",
  "libdd-trace-utils 3.0.1",
  "rmp-serde",
@@ -1787,7 +1787,7 @@ dependencies = [
 [[package]]
 name = "libdd-trace-utils"
 version = "3.0.1"
-source = "git+https://github.com/DataDog/libdatadog?rev=db05e1f8408a76075efb37ecec544d2e74217e57#db05e1f8408a76075efb37ecec544d2e74217e57"
+source = "git+https://github.com/DataDog/libdatadog?rev=4ae8ebe252451374c292efd159ce254c3f5a72e0#4ae8ebe252451374c292efd159ce254c3f5a72e0"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -1806,7 +1806,7 @@ dependencies = [
  "libdd-capabilities",
  "libdd-capabilities-impl",
  "libdd-common 4.0.0",
- "libdd-tinybytes 1.1.0 (git+https://github.com/DataDog/libdatadog?rev=db05e1f8408a76075efb37ecec544d2e74217e57)",
+ "libdd-tinybytes 1.1.0 (git+https://github.com/DataDog/libdatadog?rev=4ae8ebe252451374c292efd159ce254c3f5a72e0)",
  "libdd-trace-normalization 2.0.0",
  "libdd-trace-protobuf 3.0.1",
  "prost 0.14.3",

--- a/crates/datadog-agent-config/Cargo.toml
+++ b/crates/datadog-agent-config/Cargo.toml
@@ -6,8 +6,8 @@ license.workspace = true
 
 [dependencies]
 figment = { version = "0.10", default-features = false, features = ["yaml", "env"] }
-libdd-trace-obfuscation = { git = "https://github.com/DataDog/libdatadog", rev = "db05e1f8408a76075efb37ecec544d2e74217e57" }
-libdd-trace-utils = { git = "https://github.com/DataDog/libdatadog", rev = "db05e1f8408a76075efb37ecec544d2e74217e57" }
+libdd-trace-obfuscation = { git = "https://github.com/DataDog/libdatadog", rev = "4ae8ebe252451374c292efd159ce254c3f5a72e0" }
+libdd-trace-utils = { git = "https://github.com/DataDog/libdatadog", rev = "4ae8ebe252451374c292efd159ce254c3f5a72e0" }
 log = { version = "0.4", default-features = false }
 serde = { version = "1.0", default-features = false, features = ["derive"] }
 serde-aux = { version = "4.7", default-features = false }

--- a/crates/datadog-metrics-collector/Cargo.toml
+++ b/crates/datadog-metrics-collector/Cargo.toml
@@ -8,4 +8,4 @@ description = "Collector to read, compute, and submit enhanced metrics in Server
 [dependencies]
 dogstatsd = { path = "../dogstatsd", default-features = true }
 tracing = { version = "0.1", default-features = false }
-libdd-common = { git = "https://github.com/DataDog/libdatadog", rev = "db05e1f8408a76075efb37ecec544d2e74217e57", default-features = false }
+libdd-common = { git = "https://github.com/DataDog/libdatadog", rev = "4ae8ebe252451374c292efd159ce254c3f5a72e0", default-features = false }

--- a/crates/datadog-serverless-compat/Cargo.toml
+++ b/crates/datadog-serverless-compat/Cargo.toml
@@ -13,7 +13,7 @@ windows-pipes = ["datadog-trace-agent/windows-pipes", "dogstatsd/windows-pipes"]
 datadog-logs-agent = { path = "../datadog-logs-agent" }
 datadog-metrics-collector = { path = "../datadog-metrics-collector" }
 datadog-trace-agent = { path = "../datadog-trace-agent" }
-libdd-trace-utils = { git = "https://github.com/DataDog/libdatadog", rev = "db05e1f8408a76075efb37ecec544d2e74217e57" }
+libdd-trace-utils = { git = "https://github.com/DataDog/libdatadog", rev = "4ae8ebe252451374c292efd159ce254c3f5a72e0" }
 datadog-fips = { path = "../datadog-fips", default-features = false }
 dogstatsd = { path = "../dogstatsd", default-features = true }
 reqwest = { version = "0.12.4", default-features = false }

--- a/crates/datadog-trace-agent/Cargo.toml
+++ b/crates/datadog-trace-agent/Cargo.toml
@@ -25,16 +25,16 @@ tracing = { version = "0.1", default-features = false }
 serde = { version = "1.0.145", features = ["derive"] }
 serde_json = "1.0"
 thiserror = { version = "1.0.58", default-features = false }
-libdd-capabilities = { git = "https://github.com/DataDog/libdatadog", rev = "db05e1f8408a76075efb37ecec544d2e74217e57" }
-libdd-capabilities-impl = { git = "https://github.com/DataDog/libdatadog", rev = "db05e1f8408a76075efb37ecec544d2e74217e57" }
-libdd-common = { git = "https://github.com/DataDog/libdatadog", rev = "db05e1f8408a76075efb37ecec544d2e74217e57" }
-libdd-library-config = { git = "https://github.com/DataDog/libdatadog", rev = "db05e1f8408a76075efb37ecec544d2e74217e57" }
-libdd-trace-protobuf = { git = "https://github.com/DataDog/libdatadog", rev = "db05e1f8408a76075efb37ecec544d2e74217e57" }
-libdd-trace-stats = { git = "https://github.com/DataDog/libdatadog", rev = "db05e1f8408a76075efb37ecec544d2e74217e57" }
-libdd-trace-utils = { git = "https://github.com/DataDog/libdatadog", rev = "db05e1f8408a76075efb37ecec544d2e74217e57", features = [
+libdd-capabilities = { git = "https://github.com/DataDog/libdatadog", rev = "4ae8ebe252451374c292efd159ce254c3f5a72e0" }
+libdd-capabilities-impl = { git = "https://github.com/DataDog/libdatadog", rev = "4ae8ebe252451374c292efd159ce254c3f5a72e0" }
+libdd-common = { git = "https://github.com/DataDog/libdatadog", rev = "4ae8ebe252451374c292efd159ce254c3f5a72e0" }
+libdd-library-config = { git = "https://github.com/DataDog/libdatadog", rev = "4ae8ebe252451374c292efd159ce254c3f5a72e0" }
+libdd-trace-protobuf = { git = "https://github.com/DataDog/libdatadog", rev = "4ae8ebe252451374c292efd159ce254c3f5a72e0" }
+libdd-trace-stats = { git = "https://github.com/DataDog/libdatadog", rev = "4ae8ebe252451374c292efd159ce254c3f5a72e0" }
+libdd-trace-utils = { git = "https://github.com/DataDog/libdatadog", rev = "4ae8ebe252451374c292efd159ce254c3f5a72e0", features = [
     "mini_agent",
 ] }
-libdd-trace-obfuscation = { git = "https://github.com/DataDog/libdatadog", rev = "db05e1f8408a76075efb37ecec544d2e74217e57" }
+libdd-trace-obfuscation = { git = "https://github.com/DataDog/libdatadog", rev = "4ae8ebe252451374c292efd159ce254c3f5a72e0" }
 datadog-fips = { path = "../datadog-fips" }
 reqwest = { version = "0.12.23", features = [
     "json",
@@ -49,6 +49,6 @@ serial_test = "2.0.0"
 duplicate = "2.0.1"
 temp-env = "0.3.6"
 tempfile = "3.3.0"
-libdd-trace-utils = { git = "https://github.com/DataDog/libdatadog", rev = "db05e1f8408a76075efb37ecec544d2e74217e57", features = [
+libdd-trace-utils = { git = "https://github.com/DataDog/libdatadog", rev = "4ae8ebe252451374c292efd159ce254c3f5a72e0", features = [
     "test-utils",
 ] }

--- a/crates/datadog-trace-agent/Cargo.toml
+++ b/crates/datadog-trace-agent/Cargo.toml
@@ -43,6 +43,7 @@ reqwest = { version = "0.12.23", features = [
 bytes = "1.10.1"
 
 [dev-dependencies]
+flate2 = "1"
 rmp-serde = "1.1.1"
 serial_test = "2.0.0"
 duplicate = "2.0.1"

--- a/crates/datadog-trace-agent/src/config.rs
+++ b/crates/datadog-trace-agent/src/config.rs
@@ -1,6 +1,7 @@
 // Copyright 2023-Present Datadog, Inc. https://www.datadoghq.com/
 // SPDX-License-Identifier: Apache-2.0
 
+use crate::peer_tags::peer_tag_keys;
 use libdd_common::Endpoint;
 use std::borrow::Cow;
 use std::collections::HashMap;
@@ -110,6 +111,7 @@ pub struct Config {
     pub verify_env_timeout_ms: u64,
     pub proxy_url: Option<String>,
     pub env: String,
+    pub peer_tags: Vec<String>,
     /// Whether the agent should compute trace stats
     pub agent_stats_computation_enabled: bool,
 }
@@ -245,6 +247,7 @@ impl Config {
                 .ok(),
             tags,
             env: env::var("DD_ENV").unwrap_or_else(|_| "none".to_string()),
+            peer_tags: peer_tag_keys()?,
             agent_stats_computation_enabled: env::var("DD_AGENT_STATS_COMPUTATION_ENABLED")
                 .map(|val| val.to_lowercase() == "true")
                 .unwrap_or(false),
@@ -727,6 +730,7 @@ pub mod test_helpers {
             verify_env_timeout_ms: 1000,
             proxy_url: None,
             env: "none".to_string(),
+            peer_tags: peer_tag_keys().unwrap(),
             agent_stats_computation_enabled: false,
         }
     }

--- a/crates/datadog-trace-agent/src/lib.rs
+++ b/crates/datadog-trace-agent/src/lib.rs
@@ -12,6 +12,7 @@ pub mod config;
 pub mod env_verifier;
 pub mod http_utils;
 pub mod mini_agent;
+pub mod peer_tags;
 pub mod proxy_flusher;
 pub mod stats_concentrator_service;
 pub mod stats_flusher;

--- a/crates/datadog-trace-agent/src/mini_agent.rs
+++ b/crates/datadog-trace-agent/src/mini_agent.rs
@@ -397,9 +397,22 @@ impl MiniAgent {
             let conn = hyper_util::rt::TokioIo::new(conn);
             let server = server.clone();
             let service = service.clone();
+            let mut conn_shutdown = shutdown_rx.clone();
             joinset.spawn(async move {
-                if let Err(e) = server.serve_connection(conn, service).await {
-                    error!("TCP connection error: {e}");
+                let conn = server.serve_connection(conn, service);
+                tokio::pin!(conn);
+                tokio::select! {
+                    result = conn.as_mut() => {
+                        if let Err(e) = result {
+                            error!("TCP connection error: {e}");
+                        }
+                    }
+                    _ = conn_shutdown.changed() => {
+                        conn.as_mut().graceful_shutdown();
+                        if let Err(e) = conn.await {
+                            error!("TCP connection error during graceful shutdown: {e}");
+                        }
+                    }
                 }
             });
         }
@@ -484,9 +497,22 @@ impl MiniAgent {
             let conn = hyper_util::rt::TokioIo::new(conn);
             let server = server.clone();
             let service = service.clone();
+            let mut conn_shutdown = shutdown_rx.clone();
             joinset.spawn(async move {
-                if let Err(e) = server.serve_connection(conn, service).await {
-                    error!("Named pipe connection error: {e}");
+                let conn = server.serve_connection(conn, service);
+                tokio::pin!(conn);
+                tokio::select! {
+                    result = conn.as_mut() => {
+                        if let Err(e) = result {
+                            error!("Named pipe connection error: {e}");
+                        }
+                    }
+                    _ = conn_shutdown.changed() => {
+                        conn.as_mut().graceful_shutdown();
+                        if let Err(e) = conn.await {
+                            error!("Named pipe connection error during graceful shutdown: {e}");
+                        }
+                    }
                 }
             });
         }

--- a/crates/datadog-trace-agent/src/mini_agent.rs
+++ b/crates/datadog-trace-agent/src/mini_agent.rs
@@ -20,6 +20,7 @@ use crate::proxy_flusher::{ProxyFlusher, ProxyRequest};
 #[cfg(all(windows, feature = "windows-pipes"))]
 use tokio::net::windows::named_pipe::ServerOptions;
 
+use crate::stats_concentrator_service::SPAN_KINDS_STATS_COMPUTED;
 use crate::{config, env_verifier, stats_flusher, stats_processor, trace_flusher, trace_processor};
 use libdd_trace_protobuf::pb;
 use libdd_trace_utils::trace_utils;
@@ -638,6 +639,7 @@ impl MiniAgent {
                     PROFILING_ENDPOINT_PATH
                 ],
                 "client_drop_p0s": client_drop_p0s,
+                "span_kinds_stats_computed": SPAN_KINDS_STATS_COMPUTED,
                 "config": config_json
             }
         );

--- a/crates/datadog-trace-agent/src/mini_agent.rs
+++ b/crates/datadog-trace-agent/src/mini_agent.rs
@@ -541,6 +541,7 @@ impl MiniAgent {
                 #[cfg(not(all(windows, feature = "windows-pipes")))]
                 None,
                 config.dd_dogstatsd_port,
+                &config.peer_tags,
                 config.agent_stats_computation_enabled,
             ) {
                 Ok(res) => Ok(res),
@@ -614,6 +615,7 @@ impl MiniAgent {
         dd_apm_receiver_port: u16,
         dd_apm_windows_pipe_name: Option<&str>,
         dd_dogstatsd_port: u16,
+        peer_tags: &[String],
         agent_stats_computation_enabled: bool,
     ) -> http::Result<http_common::HttpResponse> {
         // pipe_name already includes \\.\pipe\ prefix from config
@@ -640,6 +642,7 @@ impl MiniAgent {
                 ],
                 "client_drop_p0s": client_drop_p0s,
                 "span_kinds_stats_computed": SPAN_KINDS_STATS_COMPUTED,
+                "peer_tags": peer_tags,
                 "config": config_json
             }
         );

--- a/crates/datadog-trace-agent/src/peer_tags.rs
+++ b/crates/datadog-trace-agent/src/peer_tags.rs
@@ -1,0 +1,134 @@
+// Copyright 2023-Present Datadog, Inc. https://www.datadoghq.com/
+// SPDX-License-Identifier: Apache-2.0
+
+use serde::Deserialize;
+use std::collections::{HashMap, HashSet};
+
+// The ordered list of concepts whose fallback keys form the peer tag set.
+const PEER_TAG_CONCEPTS: &[&str] = &[
+    "_dd.base_service",
+    "peer.service",
+    "peer.hostname",
+    "peer.db.name",
+    "peer.db.system",
+    "peer.cassandra.contact.points",
+    "peer.couchbase.seed.nodes",
+    "peer.messaging.destination",
+    "peer.messaging.system",
+    "peer.kafka.bootstrap.servers",
+    "peer.rpc.service",
+    "peer.rpc.system",
+    "peer.aws.s3.bucket",
+    "peer.aws.sqs.queue",
+    "peer.aws.dynamodb.table",
+    "peer.aws.kinesis.stream",
+];
+
+#[derive(Deserialize)]
+struct Mappings {
+    concepts: HashMap<String, Concept>,
+}
+
+#[derive(Deserialize)]
+struct Concept {
+    fallbacks: Vec<Fallback>,
+}
+
+#[derive(Deserialize)]
+struct Fallback {
+    name: String,
+}
+
+/// Returns the sorted, deduplicated list of peer tag keys, derived from the embedded
+/// peer_tags_mappings.json.
+pub fn peer_tag_keys() -> Result<Vec<String>, serde_json::Error> {
+    let mappings: Mappings = serde_json::from_str(include_str!("peer_tags_mappings.json"))?;
+
+    let mut seen = HashSet::new();
+    let mut keys: Vec<String> = PEER_TAG_CONCEPTS
+        .iter()
+        .filter_map(|concept| mappings.concepts.get(*concept))
+        .flat_map(|c| c.fallbacks.iter().map(|f| f.name.clone()))
+        .filter(|key| seen.insert(key.clone()))
+        .collect();
+
+    keys.sort();
+    Ok(keys)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_peer_tag_keys_sorted_and_deduped() {
+        let keys = peer_tag_keys().unwrap();
+        let mut sorted = keys.clone();
+        sorted.sort();
+        assert_eq!(keys, sorted, "peer tag keys should be sorted");
+        let unique: HashSet<_> = keys.iter().collect();
+        assert_eq!(
+            keys.len(),
+            unique.len(),
+            "peer tag keys should be deduplicated"
+        );
+    }
+
+    #[test]
+    fn test_peer_tag_keys_exact_set() {
+        let keys = peer_tag_keys().unwrap();
+        let expected: Vec<String> = {
+            let mut v: Vec<String> = vec![
+                "_dd.base_service",
+                "active_record.db.vendor",
+                "amqp.destination",
+                "amqp.exchange",
+                "amqp.queue",
+                "aws.queue.name",
+                "aws.s3.bucket",
+                "bucketname",
+                "cassandra.keyspace",
+                "db.cassandra.contact.points",
+                "db.couchbase.seed.nodes",
+                "db.hostname",
+                "db.instance",
+                "db.name",
+                "db.namespace",
+                "db.system",
+                "db.type",
+                "dns.hostname",
+                "grpc.host",
+                "hostname",
+                "http.host",
+                "http.server_name",
+                "messaging.destination",
+                "messaging.destination.name",
+                "messaging.kafka.bootstrap.servers",
+                "messaging.rabbitmq.exchange",
+                "messaging.system",
+                "mongodb.db",
+                "msmq.queue.path",
+                "net.peer.name",
+                "network.destination.ip",
+                "network.destination.name",
+                "out.host",
+                "peer.hostname",
+                "peer.service",
+                "queuename",
+                "rpc.service",
+                "rpc.system",
+                "sequel.db.vendor",
+                "server.address",
+                "streamname",
+                "tablename",
+                "topicname",
+            ]
+            .into_iter()
+            .map(String::from)
+            .collect();
+            v.sort();
+            v
+        };
+        assert_eq!(keys, expected);
+    }
+}

--- a/crates/datadog-trace-agent/src/peer_tags.rs
+++ b/crates/datadog-trace-agent/src/peer_tags.rs
@@ -40,7 +40,7 @@ struct Fallback {
 }
 
 /// Returns the sorted, deduplicated list of peer tag keys, derived from the embedded
-/// peer_tags_mappings.json.
+/// peer_tags_mappings.json filtered to the concepts listed in `PEER_TAG_CONCEPTS`.
 pub fn peer_tag_keys() -> Result<Vec<String>, serde_json::Error> {
     let mappings: Mappings = serde_json::from_str(include_str!("peer_tags_mappings.json"))?;
 
@@ -71,6 +71,20 @@ mod tests {
             keys.len(),
             unique.len(),
             "peer tag keys should be deduplicated"
+        );
+    }
+
+    #[test]
+    fn test_peer_tag_concepts_all_present_in_json() {
+        let mappings: Mappings =
+            serde_json::from_str(include_str!("peer_tags_mappings.json")).unwrap();
+        let missing: Vec<&&str> = PEER_TAG_CONCEPTS
+            .iter()
+            .filter(|c| !mappings.concepts.contains_key(**c))
+            .collect();
+        assert!(
+            missing.is_empty(),
+            "PEER_TAG_CONCEPTS entries missing from peer_tags_mappings.json: {missing:?}"
         );
     }
 

--- a/crates/datadog-trace-agent/src/peer_tags.rs
+++ b/crates/datadog-trace-agent/src/peer_tags.rs
@@ -44,14 +44,12 @@ struct Fallback {
 pub fn peer_tag_keys() -> Result<Vec<String>, serde_json::Error> {
     let mappings: Mappings = serde_json::from_str(include_str!("peer_tags_mappings.json"))?;
 
-    let mut seen = HashSet::new();
-    let mut keys: Vec<String> = PEER_TAG_CONCEPTS
+    let set: HashSet<String> = PEER_TAG_CONCEPTS
         .iter()
         .filter_map(|concept| mappings.concepts.get(*concept))
         .flat_map(|c| c.fallbacks.iter().map(|f| f.name.clone()))
-        .filter(|key| seen.insert(key.clone()))
         .collect();
-
+    let mut keys: Vec<String> = set.into_iter().collect();
     keys.sort();
     Ok(keys)
 }

--- a/crates/datadog-trace-agent/src/peer_tags_mappings.json
+++ b/crates/datadog-trace-agent/src/peer_tags_mappings.json
@@ -1,0 +1,128 @@
+{
+  "version": "0.1.0",
+  "concepts": {
+    "_dd.base_service": {
+      "canonical": "_dd.base_service",
+      "fallbacks": [
+        { "name": "_dd.base_service", "provider": "datadog", "type": "string" }
+      ]
+    },
+    "peer.service": {
+      "canonical": "peer.service",
+      "fallbacks": [
+        { "name": "peer.service", "provider": "datadog", "type": "string" }
+      ]
+    },
+    "peer.hostname": {
+      "canonical": "peer.hostname",
+      "fallbacks": [
+        { "name": "peer.hostname", "provider": "datadog", "type": "string" },
+        { "name": "hostname", "provider": "datadog", "type": "string" },
+        { "name": "net.peer.name", "provider": "otel", "type": "string" },
+        { "name": "db.hostname", "provider": "datadog", "type": "string" },
+        { "name": "network.destination.name", "provider": "otel", "type": "string" },
+        { "name": "grpc.host", "provider": "datadog", "type": "string" },
+        { "name": "http.host", "provider": "datadog", "type": "string" },
+        { "name": "server.address", "provider": "otel", "type": "string" },
+        { "name": "http.server_name", "provider": "datadog", "type": "string" },
+        { "name": "out.host", "provider": "datadog", "type": "string" },
+        { "name": "dns.hostname", "provider": "datadog", "type": "string" },
+        { "name": "network.destination.ip", "provider": "otel", "type": "string" }
+      ]
+    },
+    "peer.db.name": {
+      "canonical": "peer.db.name",
+      "fallbacks": [
+        { "name": "db.name", "provider": "otel", "type": "string" },
+        { "name": "mongodb.db", "provider": "datadog", "type": "string" },
+        { "name": "db.instance", "provider": "otel", "type": "string" },
+        { "name": "cassandra.keyspace", "provider": "datadog", "type": "string" },
+        { "name": "db.namespace", "provider": "otel", "type": "string" }
+      ]
+    },
+    "peer.db.system": {
+      "canonical": "peer.db.system",
+      "fallbacks": [
+        { "name": "db.system", "provider": "otel", "type": "string" },
+        { "name": "active_record.db.vendor", "provider": "datadog", "type": "string" },
+        { "name": "db.type", "provider": "datadog", "type": "string" },
+        { "name": "sequel.db.vendor", "provider": "datadog", "type": "string" }
+      ]
+    },
+    "peer.cassandra.contact.points": {
+      "canonical": "peer.cassandra.contact.points",
+      "fallbacks": [
+        { "name": "db.cassandra.contact.points", "provider": "otel", "type": "string" }
+      ]
+    },
+    "peer.couchbase.seed.nodes": {
+      "canonical": "peer.couchbase.seed.nodes",
+      "fallbacks": [
+        { "name": "db.couchbase.seed.nodes", "provider": "otel", "type": "string" }
+      ]
+    },
+    "peer.messaging.destination": {
+      "canonical": "peer.messaging.destination",
+      "fallbacks": [
+        { "name": "topicname", "provider": "datadog", "type": "string" },
+        { "name": "messaging.destination", "provider": "otel", "type": "string" },
+        { "name": "messaging.destination.name", "provider": "otel", "type": "string" },
+        { "name": "messaging.rabbitmq.exchange", "provider": "otel", "type": "string" },
+        { "name": "amqp.destination", "provider": "datadog", "type": "string" },
+        { "name": "amqp.queue", "provider": "datadog", "type": "string" },
+        { "name": "amqp.exchange", "provider": "datadog", "type": "string" },
+        { "name": "msmq.queue.path", "provider": "datadog", "type": "string" },
+        { "name": "aws.queue.name", "provider": "datadog", "type": "string" }
+      ]
+    },
+    "peer.messaging.system": {
+      "canonical": "peer.messaging.system",
+      "fallbacks": [
+        { "name": "messaging.system", "provider": "otel", "type": "string" }
+      ]
+    },
+    "peer.kafka.bootstrap.servers": {
+      "canonical": "peer.kafka.bootstrap.servers",
+      "fallbacks": [
+        { "name": "messaging.kafka.bootstrap.servers", "provider": "otel", "type": "string" }
+      ]
+    },
+    "peer.rpc.service": {
+      "canonical": "peer.rpc.service",
+      "fallbacks": [
+        { "name": "rpc.service", "provider": "otel", "type": "string" }
+      ]
+    },
+    "peer.rpc.system": {
+      "canonical": "peer.rpc.system",
+      "fallbacks": [
+        { "name": "rpc.system", "provider": "otel", "type": "string" }
+      ]
+    },
+    "peer.aws.s3.bucket": {
+      "canonical": "peer.aws.s3.bucket",
+      "fallbacks": [
+        { "name": "bucketname", "provider": "datadog", "type": "string" },
+        { "name": "aws.s3.bucket", "provider": "otel", "type": "string" }
+      ]
+    },
+    "peer.aws.sqs.queue": {
+      "canonical": "peer.aws.sqs.queue",
+      "fallbacks": [
+        { "name": "queuename", "provider": "datadog", "type": "string" }
+      ]
+    },
+    "peer.aws.dynamodb.table": {
+      "canonical": "peer.aws.dynamodb.table",
+      "fallbacks": [
+        { "name": "tablename", "provider": "datadog", "type": "string" }
+      ]
+    },
+    "peer.aws.kinesis.stream": {
+      "canonical": "peer.aws.kinesis.stream",
+      "fallbacks": [
+        { "name": "streamname", "provider": "datadog", "type": "string" }
+      ]
+    }
+  }
+}

--- a/crates/datadog-trace-agent/src/stats_concentrator_service.rs
+++ b/crates/datadog-trace-agent/src/stats_concentrator_service.rs
@@ -102,12 +102,11 @@ impl StatsConcentratorService {
                     // the base service and omits the version. A separate concentrator is kept per
                     // unique metadata so that each payload's stats are flushed with the metadata
                     // from the originating payload.
+                    let peer_tags = self.config.peer_tags.clone();
                     let concentrator = self
                         .concentrators
                         .entry(Arc::clone(&metadata))
-                        .or_insert_with(|| {
-                            Self::new_span_concentrator(self.config.peer_tags.clone())
-                        });
+                        .or_insert_with(|| Self::new_span_concentrator(peer_tags));
 
                     for span in &chunk.spans {
                         concentrator.add_span(span);

--- a/crates/datadog-trace-agent/src/stats_concentrator_service.rs
+++ b/crates/datadog-trace-agent/src/stats_concentrator_service.rs
@@ -102,11 +102,11 @@ impl StatsConcentratorService {
                     // the base service and omits the version. A separate concentrator is kept per
                     // unique metadata so that each payload's stats are flushed with the metadata
                     // from the originating payload.
-                    let peer_tags = self.config.peer_tags.clone();
+                    let config = Arc::clone(&self.config);
                     let concentrator = self
                         .concentrators
                         .entry(Arc::clone(&metadata))
-                        .or_insert_with(|| Self::new_span_concentrator(peer_tags));
+                        .or_insert_with(|| Self::new_span_concentrator(config.peer_tags.clone()));
 
                     for span in &chunk.spans {
                         concentrator.add_span(span);

--- a/crates/datadog-trace-agent/src/stats_concentrator_service.rs
+++ b/crates/datadog-trace-agent/src/stats_concentrator_service.rs
@@ -14,6 +14,7 @@ use tracing::error;
 
 const S_TO_NS: u64 = 1_000_000_000;
 const BUCKET_DURATION_NS: u64 = 10 * S_TO_NS; // 10 seconds
+pub const SPAN_KINDS_STATS_COMPUTED: &[&str] = &["server", "client", "producer", "consumer"];
 
 #[derive(Debug, thiserror::Error)]
 pub enum StatsError {
@@ -61,11 +62,14 @@ impl StatsConcentratorHandle {
 }
 
 fn new_concentrator() -> SpanConcentrator {
-    // TODO: set span_kinds_stats_computed and peer_tag_keys
+    // TODO: set peer_tag_keys
     SpanConcentrator::new(
         Duration::from_nanos(BUCKET_DURATION_NS),
         SystemTime::now(),
-        vec![],
+        SPAN_KINDS_STATS_COMPUTED
+            .iter()
+            .map(|s| s.to_string())
+            .collect(),
         vec![],
     )
 }

--- a/crates/datadog-trace-agent/src/stats_concentrator_service.rs
+++ b/crates/datadog-trace-agent/src/stats_concentrator_service.rs
@@ -61,19 +61,6 @@ impl StatsConcentratorHandle {
     }
 }
 
-fn new_concentrator() -> SpanConcentrator {
-    // TODO: set peer_tag_keys
-    SpanConcentrator::new(
-        Duration::from_nanos(BUCKET_DURATION_NS),
-        SystemTime::now(),
-        SPAN_KINDS_STATS_COMPUTED
-            .iter()
-            .map(|s| s.to_string())
-            .collect(),
-        vec![],
-    )
-}
-
 pub struct StatsConcentratorService {
     /// One concentrator per unique TracerMetadata.
     concentrators: HashMap<Arc<TracerMetadata>, SpanConcentrator>,
@@ -94,6 +81,18 @@ impl StatsConcentratorService {
         (service, handle)
     }
 
+    fn new_span_concentrator(peer_tags: Vec<String>) -> SpanConcentrator {
+        SpanConcentrator::new(
+            Duration::from_nanos(BUCKET_DURATION_NS),
+            SystemTime::now(),
+            SPAN_KINDS_STATS_COMPUTED
+                .iter()
+                .map(|s| s.to_string())
+                .collect(),
+            peer_tags,
+        )
+    }
+
     pub async fn run(mut self) {
         while let Some(command) = self.rx.recv().await {
             match command {
@@ -106,7 +105,9 @@ impl StatsConcentratorService {
                     let concentrator = self
                         .concentrators
                         .entry(Arc::clone(&metadata))
-                        .or_insert_with(new_concentrator);
+                        .or_insert_with(|| {
+                            Self::new_span_concentrator(self.config.peer_tags.clone())
+                        });
 
                     for span in &chunk.spans {
                         concentrator.add_span(span);

--- a/crates/datadog-trace-agent/src/trace_processor.rs
+++ b/crates/datadog-trace-agent/src/trace_processor.rs
@@ -224,6 +224,7 @@ mod tests {
 
     use crate::{
         config::{Config, Tags},
+        peer_tags::peer_tag_keys,
         trace_processor::{self, TRACER_PAYLOAD_FUNCTION_TAGS_TAG_KEY, TraceProcessor},
     };
     use libdd_common::{Endpoint, http_common};
@@ -276,7 +277,7 @@ mod tests {
             },
             tags: Tags::from_env_string("env:test,service:my-service"),
             env: "test-env".to_string(),
-            peer_tags: vec![],
+            peer_tags: peer_tag_keys().unwrap(),
             agent_stats_computation_enabled: false,
         }
     }

--- a/crates/datadog-trace-agent/src/trace_processor.rs
+++ b/crates/datadog-trace-agent/src/trace_processor.rs
@@ -276,6 +276,7 @@ mod tests {
             },
             tags: Tags::from_env_string("env:test,service:my-service"),
             env: "test-env".to_string(),
+            peer_tags: vec![],
             agent_stats_computation_enabled: false,
         }
     }

--- a/crates/datadog-trace-agent/tests/common/helpers.rs
+++ b/crates/datadog-trace-agent/tests/common/helpers.rs
@@ -3,10 +3,14 @@
 
 //! Helper functions for integration tests
 
+use flate2::read::GzDecoder;
 use hyper::{Request, Response};
 use hyper_util::rt::TokioIo;
 use libdd_common::http_common;
+use libdd_trace_protobuf::pb;
 use libdd_trace_utils::test_utils::create_test_json_span;
+use serde_json::json;
+use std::io::Read;
 use std::time::{Duration, UNIX_EPOCH};
 use tokio::time::timeout;
 
@@ -22,6 +26,44 @@ pub fn create_test_trace_payload(service: Option<&str>) -> Vec<u8> {
         span["meta"]["service"] = serde_json::Value::String(name.into());
     }
     rmp_serde::to_vec(&vec![vec![span]]).expect("Failed to serialize test trace")
+}
+
+/// Create a trace payload with a root span and two non-top-level, non-measured child spans:
+/// - a `"server"` child, which is eligible for stats only via `span_kinds_stats_computed`
+/// - an `"internal"` child, which is never eligible regardless of configuration
+pub fn create_trace_with_span_kind_children_payload() -> Vec<u8> {
+    let start = UNIX_EPOCH.elapsed().unwrap().as_nanos() as i64;
+    let root = create_test_json_span(300, 301, 0, start, false);
+    let mut server_child = create_test_json_span(300, 302, 301, start, false);
+    server_child["name"] = json!("server_op");
+    server_child["meta"]["span.kind"] = json!("server");
+    let mut internal_child = create_test_json_span(300, 303, 301, start, false);
+    internal_child["name"] = json!("internal_op");
+    internal_child["meta"]["span.kind"] = json!("internal");
+    let payload = rmp_serde::to_vec(&vec![vec![root, server_child, internal_child]])
+        .expect("Failed to serialize span kind children trace");
+    payload
+}
+
+/// Create a trace payload with a single client span that carries a `peer.service` peer tag.
+/// The span is a trace root (parent_id == 0) so it is both top-level and eligible due to span.kind.
+pub fn create_client_span_with_peer_tag_payload() -> Vec<u8> {
+    let start = UNIX_EPOCH.elapsed().unwrap().as_nanos() as i64;
+    let mut span = create_test_json_span(400, 401, 0, start, false);
+    span["meta"]["span.kind"] = json!("client");
+    span["meta"]["peer.service"] = json!("my-db");
+    rmp_serde::to_vec(&vec![vec![span]]).expect("Failed to serialize client peer tag trace")
+}
+
+/// Decompress a gzip+msgpack stats payload and deserialize it into a `StatsPayload`.
+/// The stats flusher encodes payloads as `gzip(rmp_serde::to_vec_named(StatsPayload))`.
+pub fn decode_stats_payload(body: &[u8]) -> pb::StatsPayload {
+    let mut decoder = GzDecoder::new(body);
+    let mut decompressed = Vec::new();
+    decoder
+        .read_to_end(&mut decompressed)
+        .expect("Failed to decompress stats payload");
+    rmp_serde::from_slice(&decompressed).expect("Failed to deserialize stats payload")
 }
 
 /// Send an HTTP request over TCP and return the response

--- a/crates/datadog-trace-agent/tests/common/helpers.rs
+++ b/crates/datadog-trace-agent/tests/common/helpers.rs
@@ -40,9 +40,8 @@ pub fn create_trace_with_span_kind_children_payload() -> Vec<u8> {
     let mut internal_child = create_test_json_span(300, 303, 301, start, false);
     internal_child["name"] = json!("internal_op");
     internal_child["meta"]["span.kind"] = json!("internal");
-    let payload = rmp_serde::to_vec(&vec![vec![root, server_child, internal_child]])
-        .expect("Failed to serialize span kind children trace");
-    payload
+    rmp_serde::to_vec(&vec![vec![root, server_child, internal_child]])
+        .expect("Failed to serialize span kind children trace")
 }
 
 /// Create a trace payload with a single client span that carries a `peer.service` peer tag.

--- a/crates/datadog-trace-agent/tests/integration_test.rs
+++ b/crates/datadog-trace-agent/tests/integration_test.rs
@@ -3,13 +3,18 @@
 
 mod common;
 
-use common::helpers::{create_test_trace_payload, send_tcp_request};
+use common::helpers::{
+    create_client_span_with_peer_tag_payload, create_test_trace_payload,
+    create_trace_with_span_kind_children_payload, decode_stats_payload, send_tcp_request,
+};
 use common::mock_server::MockServer;
 use common::mocks::{MockEnvVerifier, MockStatsFlusher, MockStatsProcessor, MockTraceFlusher};
 use datadog_trace_agent::{
     config::{Config, test_helpers::create_tcp_test_config},
     mini_agent::MiniAgent,
+    peer_tags::peer_tag_keys,
     proxy_flusher::ProxyFlusher,
+    stats_concentrator_service::SPAN_KINDS_STATS_COMPUTED,
     trace_flusher::TraceFlusher,
     trace_processor::ServerlessTraceProcessor,
 };
@@ -245,6 +250,21 @@ async fn test_mini_agent_tcp_handles_requests() {
         "Expected client_drop_p0s to be true"
     );
 
+    // Check span_kinds_stats_computed
+    assert_eq!(
+        json["span_kinds_stats_computed"],
+        serde_json::json!(SPAN_KINDS_STATS_COMPUTED),
+        "Expected span_kinds_stats_computed to match SPAN_KINDS_STATS_COMPUTED"
+    );
+
+    // Check peer_tags
+    let expected_peer_tags = peer_tag_keys().unwrap();
+    assert_eq!(
+        json["peer_tags"],
+        serde_json::json!(expected_peer_tags),
+        "Expected peer_tags to match peer_tag_keys()"
+    );
+
     // Check config object
     let config = &json["config"];
     assert_eq!(
@@ -326,6 +346,39 @@ async fn test_mini_agent_named_pipe_handles_requests() {
         .to_bytes();
     let json: Value =
         serde_json::from_slice(&body).expect("Failed to parse /info response as JSON");
+
+    // Check endpoints array
+    assert_eq!(
+        json["endpoints"],
+        serde_json::json!([
+            "/v0.4/traces",
+            "/v0.6/stats",
+            "/info",
+            "/profiling/v1/input"
+        ]),
+        "Expected endpoints array"
+    );
+
+    // Check client_drop_p0s flag
+    assert_eq!(
+        json["client_drop_p0s"], true,
+        "Expected client_drop_p0s to be true"
+    );
+
+    // Check span_kinds_stats_computed
+    assert_eq!(
+        json["span_kinds_stats_computed"],
+        serde_json::json!(SPAN_KINDS_STATS_COMPUTED),
+        "Expected span_kinds_stats_computed to match SPAN_KINDS_STATS_COMPUTED"
+    );
+
+    // Check peer_tags
+    let expected_peer_tags = peer_tag_keys().unwrap();
+    assert_eq!(
+        json["peer_tags"],
+        serde_json::json!(expected_peer_tags),
+        "Expected peer_tags to match peer_tag_keys()"
+    );
 
     // Check config object specific to named pipe
     let config_value = &json["config"];
@@ -523,6 +576,174 @@ async fn test_mini_agent_tcp_with_real_flushers_and_tracer_computed_stats() {
 
     // Clean up
     agent_handle.abort();
+}
+
+/// Verify that `span_kinds_stats_computed` controls which non-top-level, non-measured child spans
+/// produce stats.
+#[cfg(test)]
+#[tokio::test]
+#[serial]
+async fn test_internal_span_kind_does_not_produce_stats() {
+    let mock_server = MockServer::start().await;
+    tokio::time::sleep(Duration::from_millis(50)).await;
+
+    let mut config = create_tcp_test_config(8130);
+    configure_mock_endpoints(&mut config, &mock_server.url());
+    config.agent_stats_computation_enabled = true;
+    let config = Arc::new(config);
+    let test_port = config.dd_apm_receiver_port;
+
+    let (mini_agent, stats_concentrator_service_handle) =
+        create_mini_agent_with_real_flushers(config);
+
+    let (shutdown_tx, shutdown_rx) = tokio::sync::oneshot::channel::<()>();
+    let agent_handle = tokio::spawn(async move {
+        let _ = mini_agent
+            .start_mini_agent(shutdown_rx, Some(stats_concentrator_service_handle))
+            .await;
+    });
+
+    let mut server_ready = false;
+    for _ in 0..20 {
+        tokio::time::sleep(Duration::from_millis(50)).await;
+        if let Ok(response) = send_tcp_request(test_port, "/info", "GET", None, &[]).await
+            && response.status().is_success()
+        {
+            server_ready = true;
+            break;
+        }
+    }
+    assert!(
+        server_ready,
+        "Mini agent server failed to start within timeout"
+    );
+
+    let trace_response = send_tcp_request(
+        test_port,
+        "/v0.4/traces",
+        "POST",
+        Some(create_trace_with_span_kind_children_payload()),
+        &[],
+    )
+    .await
+    .expect("Failed to send /v0.4/traces request");
+    assert_eq!(trace_response.status(), StatusCode::OK);
+
+    tokio::time::sleep(FLUSH_WAIT_DURATION).await;
+
+    let _ = shutdown_tx.send(());
+    let _ = agent_handle.await;
+
+    let stats_reqs = mock_server.get_requests_for_path("/api/v0.2/stats");
+    assert!(
+        !stats_reqs.is_empty(),
+        "Expected a stats request from the root span"
+    );
+
+    let all_groups: Vec<_> = stats_reqs
+        .iter()
+        .map(|req| decode_stats_payload(&req.body))
+        .flat_map(|payload| {
+            payload
+                .stats
+                .into_iter()
+                .flat_map(|csp| csp.stats.into_iter())
+                .flat_map(|bucket| bucket.stats.into_iter())
+                .collect::<Vec<_>>()
+        })
+        .collect();
+
+    // server_op is only eligible via span_kinds_stats_computed — fails if span kinds are not
+    // passed to the concentrator
+    assert!(
+        all_groups.iter().any(|g| g.name == "server_op"),
+        "Expected server_op to appear in stats (eligible via span_kinds_stats_computed), got: {:?}",
+        all_groups.iter().map(|g| &g.name).collect::<Vec<_>>()
+    );
+
+    // internal_op is never eligible regardless of configuration
+    assert!(
+        !all_groups.iter().any(|g| g.name == "internal_op"),
+        "internal_op should not appear in stats, but got: {:?}",
+        all_groups.iter().map(|g| &g.name).collect::<Vec<_>>()
+    );
+}
+
+/// Verify that peer tags are present in the flushed stats payload when a client span carries a
+/// peer tag (`peer.service`).
+#[cfg(test)]
+#[tokio::test]
+#[serial]
+async fn test_peer_tags_in_flushed_stats() {
+    let mock_server = MockServer::start().await;
+    tokio::time::sleep(Duration::from_millis(50)).await;
+
+    let mut config = create_tcp_test_config(8131);
+    configure_mock_endpoints(&mut config, &mock_server.url());
+    config.agent_stats_computation_enabled = true;
+    let config = Arc::new(config);
+    let test_port = config.dd_apm_receiver_port;
+
+    let (mini_agent, stats_concentrator_service_handle) =
+        create_mini_agent_with_real_flushers(config);
+
+    let (shutdown_tx, shutdown_rx) = tokio::sync::oneshot::channel::<()>();
+    let agent_handle = tokio::spawn(async move {
+        let _ = mini_agent
+            .start_mini_agent(shutdown_rx, Some(stats_concentrator_service_handle))
+            .await;
+    });
+
+    let mut server_ready = false;
+    for _ in 0..20 {
+        tokio::time::sleep(Duration::from_millis(50)).await;
+        if let Ok(response) = send_tcp_request(test_port, "/info", "GET", None, &[]).await
+            && response.status().is_success()
+        {
+            server_ready = true;
+            break;
+        }
+    }
+    assert!(
+        server_ready,
+        "Mini agent server failed to start within timeout"
+    );
+
+    let trace_response = send_tcp_request(
+        test_port,
+        "/v0.4/traces",
+        "POST",
+        Some(create_client_span_with_peer_tag_payload()),
+        &[],
+    )
+    .await
+    .expect("Failed to send /v0.4/traces request");
+    assert_eq!(trace_response.status(), StatusCode::OK);
+
+    tokio::time::sleep(FLUSH_WAIT_DURATION).await;
+
+    let _ = shutdown_tx.send(());
+    let _ = agent_handle.await;
+
+    let stats_reqs = mock_server.get_requests_for_path("/api/v0.2/stats");
+    assert!(
+        !stats_reqs.is_empty(),
+        "Expected at least one stats request"
+    );
+
+    let payload = decode_stats_payload(&stats_reqs[0].body);
+    let all_peer_tags: Vec<&str> = payload
+        .stats
+        .iter()
+        .flat_map(|csp| &csp.stats)
+        .flat_map(|bucket| &bucket.stats)
+        .flat_map(|group| group.peer_tags.iter().map(String::as_str))
+        .collect();
+
+    assert!(
+        all_peer_tags.contains(&"peer.service:my-db"),
+        "Expected peer.service:my-db in stats peer_tags, got: {all_peer_tags:?}"
+    );
 }
 
 #[cfg(all(test, windows, feature = "windows-pipes"))]

--- a/crates/datadog-trace-agent/tests/integration_test.rs
+++ b/crates/datadog-trace-agent/tests/integration_test.rs
@@ -587,7 +587,7 @@ async fn test_internal_span_kind_does_not_produce_stats() {
     let mock_server = MockServer::start().await;
     tokio::time::sleep(Duration::from_millis(50)).await;
 
-    let mut config = create_tcp_test_config(8130);
+    let mut config = create_tcp_test_config(8132);
     configure_mock_endpoints(&mut config, &mock_server.url());
     config.agent_stats_computation_enabled = true;
     let config = Arc::new(config);

--- a/crates/datadog-trace-agent/tests/integration_test.rs
+++ b/crates/datadog-trace-agent/tests/integration_test.rs
@@ -596,7 +596,7 @@ async fn test_internal_span_kind_does_not_produce_stats() {
     let (mini_agent, stats_concentrator_service_handle) =
         create_mini_agent_with_real_flushers(config);
 
-    let (shutdown_tx, shutdown_rx) = tokio::sync::oneshot::channel::<()>();
+    let (shutdown_tx, shutdown_rx) = tokio::sync::watch::channel(false);
     let agent_handle = tokio::spawn(async move {
         let _ = mini_agent
             .start_mini_agent(shutdown_rx, Some(stats_concentrator_service_handle))
@@ -631,7 +631,7 @@ async fn test_internal_span_kind_does_not_produce_stats() {
 
     tokio::time::sleep(FLUSH_WAIT_DURATION).await;
 
-    let _ = shutdown_tx.send(());
+    let _ = shutdown_tx.send(true);
     let _ = agent_handle.await;
 
     let stats_reqs = mock_server.get_requests_for_path("/api/v0.2/stats");
@@ -687,7 +687,7 @@ async fn test_peer_tags_in_flushed_stats() {
     let (mini_agent, stats_concentrator_service_handle) =
         create_mini_agent_with_real_flushers(config);
 
-    let (shutdown_tx, shutdown_rx) = tokio::sync::oneshot::channel::<()>();
+    let (shutdown_tx, shutdown_rx) = tokio::sync::watch::channel(false);
     let agent_handle = tokio::spawn(async move {
         let _ = mini_agent
             .start_mini_agent(shutdown_rx, Some(stats_concentrator_service_handle))
@@ -722,7 +722,7 @@ async fn test_peer_tags_in_flushed_stats() {
 
     tokio::time::sleep(FLUSH_WAIT_DURATION).await;
 
-    let _ = shutdown_tx.send(());
+    let _ = shutdown_tx.send(true);
     let _ = agent_handle.await;
 
     let stats_reqs = mock_server.get_requests_for_path("/api/v0.2/stats");


### PR DESCRIPTION
### What does this PR do?

- Pass `span_kinds_stats_computed` and `peer_tags` to span concentrator.
- Include `span_kinds_stats_computed` and `peer_tags` in `/info` endpoint response.

### Motivation

- Compute stats for certain span kinds even if they are not top level or measured spans.
  * `server`
  * `client`
  * `producer`
  * `consumer`
- Add peer tags as additional tags on computed stats

https://datadoghq.atlassian.net/browse/SVLS-8977

### Additional Notes

- [Span kinds from Go agent](https://github.com/DataDog/datadog-agent/blob/d7f52b142d77bdc22bb8196ca498e7e0f014378f/pkg/trace/stats/span_concentrator.go#L315-L338)
- [Peer tags from Go agent](https://github.com/DataDog/datadog-agent/blob/main/pkg/trace/semantics/mappings.json)
- Updates libdatadog revision for https://github.com/DataDog/libdatadog/pull/1944
- Updated shutdown logic due to flaky test `test_mini_agent_named_pipe_with_real_flushers`. Now, when a shutdown signal arrives, each connection gets a chance to finish its current request before closing, rather than potentially being killed mid-response.
```
    thread 'test_mini_agent_named_pipe_with_real_flushers' (2036) panicked at crates\datadog-trace-agent\tests\integration_test.rs:49:5:
    Timed out after 60s waiting for request at /api/v0.2/stats
```

### Describe how to test/QA your changes

- Unit tests
  * Expected peer tags are parsed from json
  * Parsed peer tags are sorted and do not contain duplicates
- Integration tests
  * `/info` endpoint contains expected values for `span_kinds_stats_computed` and `peer_tags`
  * Stats computed for a non-top-level, non-measured, eligible span kind (`server`)
  * Stats not computed for a non-top-level, non-measured, ineligible span kind ('internal`)
  * Peer tags included on flushed stats
- End to end test (manual)
  * Deployed Azure Function with Service Bus trigger and validated that stats are computed for service bus spans with relevant peer tags
