### PR TITLE
feat: add fallback to DD_VERSION for trace stats computation

### DIFF
--- a/crates/datadog-trace-agent/src/config.rs
+++ b/crates/datadog-trace-agent/src/config.rs
@@ -110,6 +110,7 @@ pub struct Config {
     pub verify_env_timeout_ms: u64,
     pub proxy_url: Option<String>,
     pub env: String,
+    pub version: String,
     /// Whether the agent should compute trace stats
     pub agent_stats_computation_enabled: bool,
 }
@@ -255,6 +256,7 @@ impl Config {
                 .ok(),
             tags,
             env: env::var("DD_ENV").unwrap_or_else(|_| "none".to_string()),
+            version: env::var("DD_VERSION").unwrap_or_default(),
             agent_stats_computation_enabled: env::var("DD_AGENT_STATS_COMPUTATION_ENABLED")
                 .map(|val| val.to_lowercase() == "true")
                 .unwrap_or(false),
@@ -733,6 +735,7 @@ pub mod test_helpers {
             verify_env_timeout_ms: 1000,
             proxy_url: None,
             env: "none".to_string(),
+            version: String::new(),
             agent_stats_computation_enabled: false,
         }
     }

--- a/crates/datadog-trace-agent/src/stats_concentrator_service.rs
+++ b/crates/datadog-trace-agent/src/stats_concentrator_service.rs
@@ -137,7 +137,12 @@ impl StatsConcentratorService {
                         .clone()
                         .filter(|s| !s.is_empty())
                         .unwrap_or_else(|| self.config.env.clone()),
-                    version: metadata.service_version.clone().unwrap_or_default(),
+                    // Prefer version from the tracer payload, fall back to agent config
+                    version: metadata
+                        .service_version
+                        .clone()
+                        .filter(|s| !s.is_empty())
+                        .unwrap_or_else(|| self.config.version.clone()),
                     lang: metadata.tracer_language.clone(),
                     tracer_version: metadata.tracer_version.clone(),
                     // Not set for agent-computed stats; runtime_id identifies tracer-computed payloads

--- a/crates/datadog-trace-agent/src/trace_processor.rs
+++ b/crates/datadog-trace-agent/src/trace_processor.rs
@@ -276,6 +276,7 @@ mod tests {
             },
             tags: Tags::from_env_string("env:test,service:my-service"),
             env: "test-env".to_string(),
+            version: String::new(),
             agent_stats_computation_enabled: false,
         }
     }


### PR DESCRIPTION
### What does this PR do?

Adds a fallback in trace stats computation to use `DD_VERSION` if no version is available in the trace payload.

### Motivation

Some initial traces from the .NET tracer do not include the version in the trace payload.

https://datadoghq.atlassian.net/browse/SVLS-9006

<img width="1800" height="428" alt="Screenshot 2026-05-05 at 3 33 59 PM" src="https://github.com/user-attachments/assets/6a07b1f8-5ea1-40d6-a790-f7490f617df8" />

### Additional Notes

<!-- Any other relevant context that would be helpful. -->

### Describe how to test/QA your changes

Invoked .NET functions that undercounted some stats by version and validated that all trace stats submitted to intake have a version.

```
plow "$url" -c 50 -n 50000
```

<img width="741" height="72" alt="Screenshot 2026-05-04 at 2 43 03 PM" src="https://github.com/user-attachments/assets/2b54641b-6d93-481e-bc18-2662a7bd7b29" />

With 50% sampling enabled:

<img width="746" height="116" alt="Screenshot 2026-05-04 at 4 31 16 PM" src="https://github.com/user-attachments/assets/d1bf61a9-8e1d-469c-9ee0-a3e1e51e4e53" />

