### PR TITLE
chore(deps): bump libdatadog to 0a70516

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1444,7 +1444,7 @@ checksum = "b5b646652bf6661599e1da8901b3b9522896f01e736bad5f723fe7a3a27f899d"
 [[package]]
 name = "libdd-capabilities"
 version = "1.0.0"
-source = "git+https://github.com/DataDog/libdatadog?rev=d7eef8031192d0ee79ba64cd824804c5a57abacf#d7eef8031192d0ee79ba64cd824804c5a57abacf"
+source = "git+https://github.com/DataDog/libdatadog?rev=0a70516d66314efdd7115644b0da4b3b3e0958e0#0a70516d66314efdd7115644b0da4b3b3e0958e0"
 dependencies = [
  "anyhow",
  "bytes",
@@ -1455,7 +1455,7 @@ dependencies = [
 [[package]]
 name = "libdd-capabilities-impl"
 version = "1.0.0"
-source = "git+https://github.com/DataDog/libdatadog?rev=d7eef8031192d0ee79ba64cd824804c5a57abacf#d7eef8031192d0ee79ba64cd824804c5a57abacf"
+source = "git+https://github.com/DataDog/libdatadog?rev=0a70516d66314efdd7115644b0da4b3b3e0958e0#0a70516d66314efdd7115644b0da4b3b3e0958e0"
 dependencies = [
  "bytes",
  "http",
@@ -1498,7 +1498,7 @@ dependencies = [
 [[package]]
 name = "libdd-common"
 version = "4.0.0"
-source = "git+https://github.com/DataDog/libdatadog?rev=d7eef8031192d0ee79ba64cd824804c5a57abacf#d7eef8031192d0ee79ba64cd824804c5a57abacf"
+source = "git+https://github.com/DataDog/libdatadog?rev=0a70516d66314efdd7115644b0da4b3b3e0958e0#0a70516d66314efdd7115644b0da4b3b3e0958e0"
 dependencies = [
  "anyhow",
  "bytes",
@@ -1571,7 +1571,7 @@ dependencies = [
 [[package]]
 name = "libdd-ddsketch"
 version = "1.0.1"
-source = "git+https://github.com/DataDog/libdatadog?rev=d7eef8031192d0ee79ba64cd824804c5a57abacf#d7eef8031192d0ee79ba64cd824804c5a57abacf"
+source = "git+https://github.com/DataDog/libdatadog?rev=0a70516d66314efdd7115644b0da4b3b3e0958e0#0a70516d66314efdd7115644b0da4b3b3e0958e0"
 dependencies = [
  "prost 0.14.3",
 ]
@@ -1593,7 +1593,7 @@ dependencies = [
 [[package]]
 name = "libdd-library-config"
 version = "1.1.0"
-source = "git+https://github.com/DataDog/libdatadog?rev=d7eef8031192d0ee79ba64cd824804c5a57abacf#d7eef8031192d0ee79ba64cd824804c5a57abacf"
+source = "git+https://github.com/DataDog/libdatadog?rev=0a70516d66314efdd7115644b0da4b3b3e0958e0#0a70516d66314efdd7115644b0da4b3b3e0958e0"
 dependencies = [
  "anyhow",
  "libc",
@@ -1610,7 +1610,7 @@ dependencies = [
 [[package]]
 name = "libdd-shared-runtime"
 version = "0.1.0"
-source = "git+https://github.com/DataDog/libdatadog?rev=d7eef8031192d0ee79ba64cd824804c5a57abacf#d7eef8031192d0ee79ba64cd824804c5a57abacf"
+source = "git+https://github.com/DataDog/libdatadog?rev=0a70516d66314efdd7115644b0da4b3b3e0958e0#0a70516d66314efdd7115644b0da4b3b3e0958e0"
 dependencies = [
  "async-trait",
  "futures",
@@ -1658,7 +1658,7 @@ dependencies = [
 [[package]]
 name = "libdd-tinybytes"
 version = "1.1.0"
-source = "git+https://github.com/DataDog/libdatadog?rev=d7eef8031192d0ee79ba64cd824804c5a57abacf#d7eef8031192d0ee79ba64cd824804c5a57abacf"
+source = "git+https://github.com/DataDog/libdatadog?rev=0a70516d66314efdd7115644b0da4b3b3e0958e0#0a70516d66314efdd7115644b0da4b3b3e0958e0"
 dependencies = [
  "serde",
 ]
@@ -1676,7 +1676,7 @@ dependencies = [
 [[package]]
 name = "libdd-trace-normalization"
 version = "2.0.0"
-source = "git+https://github.com/DataDog/libdatadog?rev=d7eef8031192d0ee79ba64cd824804c5a57abacf#d7eef8031192d0ee79ba64cd824804c5a57abacf"
+source = "git+https://github.com/DataDog/libdatadog?rev=0a70516d66314efdd7115644b0da4b3b3e0958e0#0a70516d66314efdd7115644b0da4b3b3e0958e0"
 dependencies = [
  "anyhow",
  "libdd-trace-protobuf 3.0.1",
@@ -1685,7 +1685,7 @@ dependencies = [
 [[package]]
 name = "libdd-trace-obfuscation"
 version = "2.0.0"
-source = "git+https://github.com/DataDog/libdatadog?rev=d7eef8031192d0ee79ba64cd824804c5a57abacf#d7eef8031192d0ee79ba64cd824804c5a57abacf"
+source = "git+https://github.com/DataDog/libdatadog?rev=0a70516d66314efdd7115644b0da4b3b3e0958e0#0a70516d66314efdd7115644b0da4b3b3e0958e0"
 dependencies = [
  "anyhow",
  "fluent-uri",
@@ -1713,7 +1713,7 @@ dependencies = [
 [[package]]
 name = "libdd-trace-protobuf"
 version = "3.0.1"
-source = "git+https://github.com/DataDog/libdatadog?rev=d7eef8031192d0ee79ba64cd824804c5a57abacf#d7eef8031192d0ee79ba64cd824804c5a57abacf"
+source = "git+https://github.com/DataDog/libdatadog?rev=0a70516d66314efdd7115644b0da4b3b3e0958e0#0a70516d66314efdd7115644b0da4b3b3e0958e0"
 dependencies = [
  "prost 0.14.3",
  "serde",
@@ -1735,7 +1735,7 @@ dependencies = [
 [[package]]
 name = "libdd-trace-stats"
 version = "2.0.0"
-source = "git+https://github.com/DataDog/libdatadog?rev=d7eef8031192d0ee79ba64cd824804c5a57abacf#d7eef8031192d0ee79ba64cd824804c5a57abacf"
+source = "git+https://github.com/DataDog/libdatadog?rev=0a70516d66314efdd7115644b0da4b3b3e0958e0#0a70516d66314efdd7115644b0da4b3b3e0958e0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1744,7 +1744,7 @@ dependencies = [
  "libdd-capabilities",
  "libdd-capabilities-impl",
  "libdd-common 4.0.0",
- "libdd-ddsketch 1.0.1 (git+https://github.com/DataDog/libdatadog?rev=d7eef8031192d0ee79ba64cd824804c5a57abacf)",
+ "libdd-ddsketch 1.0.1 (git+https://github.com/DataDog/libdatadog?rev=0a70516d66314efdd7115644b0da4b3b3e0958e0)",
  "libdd-shared-runtime",
  "libdd-trace-protobuf 3.0.1",
  "libdd-trace-utils 3.0.1",
@@ -1786,7 +1786,7 @@ dependencies = [
 [[package]]
 name = "libdd-trace-utils"
 version = "3.0.1"
-source = "git+https://github.com/DataDog/libdatadog?rev=d7eef8031192d0ee79ba64cd824804c5a57abacf#d7eef8031192d0ee79ba64cd824804c5a57abacf"
+source = "git+https://github.com/DataDog/libdatadog?rev=0a70516d66314efdd7115644b0da4b3b3e0958e0#0a70516d66314efdd7115644b0da4b3b3e0958e0"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -1805,7 +1805,7 @@ dependencies = [
  "libdd-capabilities",
  "libdd-capabilities-impl",
  "libdd-common 4.0.0",
- "libdd-tinybytes 1.1.0 (git+https://github.com/DataDog/libdatadog?rev=d7eef8031192d0ee79ba64cd824804c5a57abacf)",
+ "libdd-tinybytes 1.1.0 (git+https://github.com/DataDog/libdatadog?rev=0a70516d66314efdd7115644b0da4b3b3e0958e0)",
  "libdd-trace-normalization 2.0.0",
  "libdd-trace-protobuf 3.0.1",
  "prost 0.14.3",

--- a/crates/datadog-agent-config/Cargo.toml
+++ b/crates/datadog-agent-config/Cargo.toml
@@ -6,8 +6,8 @@ license.workspace = true
 
 [dependencies]
 figment = { version = "0.10", default-features = false, features = ["yaml", "env"] }
-libdd-trace-obfuscation = { git = "https://github.com/DataDog/libdatadog", rev = "d7eef8031192d0ee79ba64cd824804c5a57abacf" }
-libdd-trace-utils = { git = "https://github.com/DataDog/libdatadog", rev = "d7eef8031192d0ee79ba64cd824804c5a57abacf" }
+libdd-trace-obfuscation = { git = "https://github.com/DataDog/libdatadog", rev = "0a70516d66314efdd7115644b0da4b3b3e0958e0" }
+libdd-trace-utils = { git = "https://github.com/DataDog/libdatadog", rev = "0a70516d66314efdd7115644b0da4b3b3e0958e0" }
 log = { version = "0.4", default-features = false }
 serde = { version = "1.0", default-features = false, features = ["derive"] }
 serde-aux = { version = "4.7", default-features = false }

--- a/crates/datadog-metrics-collector/Cargo.toml
+++ b/crates/datadog-metrics-collector/Cargo.toml
@@ -8,4 +8,4 @@ description = "Collector to read, compute, and submit enhanced metrics in Server
 [dependencies]
 dogstatsd = { path = "../dogstatsd", default-features = true }
 tracing = { version = "0.1", default-features = false }
-libdd-common = { git = "https://github.com/DataDog/libdatadog", rev = "d7eef8031192d0ee79ba64cd824804c5a57abacf", default-features = false }
+libdd-common = { git = "https://github.com/DataDog/libdatadog", rev = "0a70516d66314efdd7115644b0da4b3b3e0958e0", default-features = false }

--- a/crates/datadog-serverless-compat/Cargo.toml
+++ b/crates/datadog-serverless-compat/Cargo.toml
@@ -13,7 +13,7 @@ windows-pipes = ["datadog-trace-agent/windows-pipes", "dogstatsd/windows-pipes"]
 datadog-logs-agent = { path = "../datadog-logs-agent" }
 datadog-metrics-collector = { path = "../datadog-metrics-collector" }
 datadog-trace-agent = { path = "../datadog-trace-agent" }
-libdd-trace-utils = { git = "https://github.com/DataDog/libdatadog", rev = "d7eef8031192d0ee79ba64cd824804c5a57abacf" }
+libdd-trace-utils = { git = "https://github.com/DataDog/libdatadog", rev = "0a70516d66314efdd7115644b0da4b3b3e0958e0" }
 datadog-fips = { path = "../datadog-fips", default-features = false }
 dogstatsd = { path = "../dogstatsd", default-features = true }
 reqwest = { version = "0.12.4", default-features = false }

--- a/crates/datadog-trace-agent/Cargo.toml
+++ b/crates/datadog-trace-agent/Cargo.toml
@@ -25,16 +25,16 @@ tracing = { version = "0.1", default-features = false }
 serde = { version = "1.0.145", features = ["derive"] }
 serde_json = "1.0"
 thiserror = { version = "1.0.58", default-features = false }
-libdd-capabilities = { git = "https://github.com/DataDog/libdatadog", rev = "d7eef8031192d0ee79ba64cd824804c5a57abacf" }
-libdd-capabilities-impl = { git = "https://github.com/DataDog/libdatadog", rev = "d7eef8031192d0ee79ba64cd824804c5a57abacf" }
-libdd-common = { git = "https://github.com/DataDog/libdatadog", rev = "d7eef8031192d0ee79ba64cd824804c5a57abacf" }
-libdd-library-config = { git = "https://github.com/DataDog/libdatadog", rev = "d7eef8031192d0ee79ba64cd824804c5a57abacf" }
-libdd-trace-protobuf = { git = "https://github.com/DataDog/libdatadog", rev = "d7eef8031192d0ee79ba64cd824804c5a57abacf" }
-libdd-trace-stats = { git = "https://github.com/DataDog/libdatadog", rev = "d7eef8031192d0ee79ba64cd824804c5a57abacf" }
-libdd-trace-utils = { git = "https://github.com/DataDog/libdatadog", rev = "d7eef8031192d0ee79ba64cd824804c5a57abacf", features = [
+libdd-capabilities = { git = "https://github.com/DataDog/libdatadog", rev = "0a70516d66314efdd7115644b0da4b3b3e0958e0" }
+libdd-capabilities-impl = { git = "https://github.com/DataDog/libdatadog", rev = "0a70516d66314efdd7115644b0da4b3b3e0958e0" }
+libdd-common = { git = "https://github.com/DataDog/libdatadog", rev = "0a70516d66314efdd7115644b0da4b3b3e0958e0" }
+libdd-library-config = { git = "https://github.com/DataDog/libdatadog", rev = "0a70516d66314efdd7115644b0da4b3b3e0958e0" }
+libdd-trace-protobuf = { git = "https://github.com/DataDog/libdatadog", rev = "0a70516d66314efdd7115644b0da4b3b3e0958e0" }
+libdd-trace-stats = { git = "https://github.com/DataDog/libdatadog", rev = "0a70516d66314efdd7115644b0da4b3b3e0958e0" }
+libdd-trace-utils = { git = "https://github.com/DataDog/libdatadog", rev = "0a70516d66314efdd7115644b0da4b3b3e0958e0", features = [
     "mini_agent",
 ] }
-libdd-trace-obfuscation = { git = "https://github.com/DataDog/libdatadog", rev = "d7eef8031192d0ee79ba64cd824804c5a57abacf" }
+libdd-trace-obfuscation = { git = "https://github.com/DataDog/libdatadog", rev = "0a70516d66314efdd7115644b0da4b3b3e0958e0" }
 datadog-fips = { path = "../datadog-fips" }
 reqwest = { version = "0.12.23", features = [
     "json",
@@ -48,6 +48,6 @@ serial_test = "2.0.0"
 duplicate = "2.0.1"
 temp-env = "0.3.6"
 tempfile = "3.3.0"
-libdd-trace-utils = { git = "https://github.com/DataDog/libdatadog", rev = "d7eef8031192d0ee79ba64cd824804c5a57abacf", features = [
+libdd-trace-utils = { git = "https://github.com/DataDog/libdatadog", rev = "0a70516d66314efdd7115644b0da4b3b3e0958e0", features = [
     "test-utils",
 ] }


### PR DESCRIPTION
## Summary

Bumps the `libdd-*` git revs in this workspace from `d7eef803` to `0a70516d66314efdd7115644b0da4b3b3e0958e0` (current tip of libdatadog `main`).

**No code changes are required.** The previous pin `d7eef803...` is itself the libdatadog commit `feat: add Hash trait to TracerMetadata (#1931)`, so the workspace was already past the v32.0.0 breaking changes (capability-traits HTTP architecture from #1555 and the `TracerMetadata` derive removal that #1922/#1931 reversed). The HTTP-trait migration was absorbed in an earlier libdatadog bump — see `crates/datadog-trace-agent/src/trace_flusher.rs`, where `ProxyHttpClient` already implements `HttpClientTrait` and `coalesced_traces.send(&http_client)` is called against it.

## What changed and why

Updated `libdd-*` revs to `0a70516` in:
- `crates/datadog-serverless-compat/Cargo.toml`
- `crates/datadog-metrics-collector/Cargo.toml`
- `crates/datadog-trace-agent/Cargo.toml`
- `crates/datadog-agent-config/Cargo.toml`
- `Cargo.lock` (regenerated via `cargo update --workspace`)

### Range covered by this bump

`d7eef803..0a70516` is ~10 libdatadog commits — none of them break this workspace's public surface. Notable items:

- **`53c8c16` feat(http-client): add knob to disable connection pooling (#1933)** — `libdd-common` gains an opt-in setting; this workspace doesn't need it (existing pool behavior is unchanged).
- **`27aa92c` feat(libdd-trace-utils): check for empty value in header `datadog-client-computed-stats`** — defensive parsing change; transparent to callers.
- **`b1b58fc` feat(telemetry): add session id support to trace export** — additive on the telemetry surface; no impact here.
- **`5db2a80` feat(ffe)!: remove extra_logging** — feature-flag-engine breaking change; this workspace doesn't depend on `libdd-ffe`.
- Several sidecar / tracer-flare / FFI commits that don't touch the crates this workspace pulls in.

## Companion PR

DataDog/datadog-lambda-extension#1218 bumps bottlecap to the same SHA. Bottlecap *did* require code changes — it had not yet adopted the v32 `HttpClientTrait` architecture and was on a much older libdatadog SHA (`c8121f42`), so the bump there spans the v32.0.0 breaking changes that this workspace already absorbed.

## Test plan

- [x] `cargo check --workspace --all-targets`
- [x] `cargo clippy --workspace --all-targets`
- [x] `cargo test -p datadog-trace-agent stats_concentrator` — both existing tests pass
- [x] `cargo fmt --all -- --check`