### PR TITLE
feat: update libdatadog revision to 0a3304c6aaf84738786b670d706a01edc22dab81

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1446,7 +1446,7 @@ checksum = "b5b646652bf6661599e1da8901b3b9522896f01e736bad5f723fe7a3a27f899d"
 [[package]]
 name = "libdd-capabilities"
 version = "1.0.0"
-source = "git+https://github.com/DataDog/libdatadog?rev=4ae8ebe252451374c292efd159ce254c3f5a72e0#4ae8ebe252451374c292efd159ce254c3f5a72e0"
+source = "git+https://github.com/DataDog/libdatadog?rev=0a3304c6aaf84738786b670d706a01edc22dab81#0a3304c6aaf84738786b670d706a01edc22dab81"
 dependencies = [
  "anyhow",
  "bytes",
@@ -1457,13 +1457,14 @@ dependencies = [
 [[package]]
 name = "libdd-capabilities-impl"
 version = "1.0.0"
-source = "git+https://github.com/DataDog/libdatadog?rev=4ae8ebe252451374c292efd159ce254c3f5a72e0#4ae8ebe252451374c292efd159ce254c3f5a72e0"
+source = "git+https://github.com/DataDog/libdatadog?rev=0a3304c6aaf84738786b670d706a01edc22dab81#0a3304c6aaf84738786b670d706a01edc22dab81"
 dependencies = [
  "bytes",
  "http",
  "http-body-util",
  "libdd-capabilities",
  "libdd-common 4.0.0",
+ "tokio",
 ]
 
 [[package]]
@@ -1500,7 +1501,7 @@ dependencies = [
 [[package]]
 name = "libdd-common"
 version = "4.0.0"
-source = "git+https://github.com/DataDog/libdatadog?rev=4ae8ebe252451374c292efd159ce254c3f5a72e0#4ae8ebe252451374c292efd159ce254c3f5a72e0"
+source = "git+https://github.com/DataDog/libdatadog?rev=0a3304c6aaf84738786b670d706a01edc22dab81#0a3304c6aaf84738786b670d706a01edc22dab81"
 dependencies = [
  "anyhow",
  "bytes",
@@ -1573,7 +1574,7 @@ dependencies = [
 [[package]]
 name = "libdd-ddsketch"
 version = "1.0.1"
-source = "git+https://github.com/DataDog/libdatadog?rev=4ae8ebe252451374c292efd159ce254c3f5a72e0#4ae8ebe252451374c292efd159ce254c3f5a72e0"
+source = "git+https://github.com/DataDog/libdatadog?rev=0a3304c6aaf84738786b670d706a01edc22dab81#0a3304c6aaf84738786b670d706a01edc22dab81"
 dependencies = [
  "prost 0.14.3",
 ]
@@ -1595,7 +1596,7 @@ dependencies = [
 [[package]]
 name = "libdd-library-config"
 version = "1.1.0"
-source = "git+https://github.com/DataDog/libdatadog?rev=4ae8ebe252451374c292efd159ce254c3f5a72e0#4ae8ebe252451374c292efd159ce254c3f5a72e0"
+source = "git+https://github.com/DataDog/libdatadog?rev=0a3304c6aaf84738786b670d706a01edc22dab81#0a3304c6aaf84738786b670d706a01edc22dab81"
 dependencies = [
  "anyhow",
  "libc",
@@ -1612,15 +1613,18 @@ dependencies = [
 [[package]]
 name = "libdd-shared-runtime"
 version = "0.1.0"
-source = "git+https://github.com/DataDog/libdatadog?rev=4ae8ebe252451374c292efd159ce254c3f5a72e0#4ae8ebe252451374c292efd159ce254c3f5a72e0"
+source = "git+https://github.com/DataDog/libdatadog?rev=0a3304c6aaf84738786b670d706a01edc22dab81#0a3304c6aaf84738786b670d706a01edc22dab81"
 dependencies = [
  "async-trait",
  "futures",
+ "futures-util",
  "libdd-capabilities",
+ "libdd-capabilities-impl",
  "libdd-common 4.0.0",
  "tokio",
  "tokio-util",
  "tracing",
+ "wasm-bindgen-futures",
 ]
 
 [[package]]
@@ -1660,7 +1664,7 @@ dependencies = [
 [[package]]
 name = "libdd-tinybytes"
 version = "1.1.0"
-source = "git+https://github.com/DataDog/libdatadog?rev=4ae8ebe252451374c292efd159ce254c3f5a72e0#4ae8ebe252451374c292efd159ce254c3f5a72e0"
+source = "git+https://github.com/DataDog/libdatadog?rev=0a3304c6aaf84738786b670d706a01edc22dab81#0a3304c6aaf84738786b670d706a01edc22dab81"
 dependencies = [
  "serde",
 ]
@@ -1678,7 +1682,7 @@ dependencies = [
 [[package]]
 name = "libdd-trace-normalization"
 version = "2.0.0"
-source = "git+https://github.com/DataDog/libdatadog?rev=4ae8ebe252451374c292efd159ce254c3f5a72e0#4ae8ebe252451374c292efd159ce254c3f5a72e0"
+source = "git+https://github.com/DataDog/libdatadog?rev=0a3304c6aaf84738786b670d706a01edc22dab81#0a3304c6aaf84738786b670d706a01edc22dab81"
 dependencies = [
  "anyhow",
  "libdd-trace-protobuf 3.0.1",
@@ -1687,7 +1691,7 @@ dependencies = [
 [[package]]
 name = "libdd-trace-obfuscation"
 version = "2.0.0"
-source = "git+https://github.com/DataDog/libdatadog?rev=4ae8ebe252451374c292efd159ce254c3f5a72e0#4ae8ebe252451374c292efd159ce254c3f5a72e0"
+source = "git+https://github.com/DataDog/libdatadog?rev=0a3304c6aaf84738786b670d706a01edc22dab81#0a3304c6aaf84738786b670d706a01edc22dab81"
 dependencies = [
  "anyhow",
  "fluent-uri",
@@ -1714,7 +1718,7 @@ dependencies = [
 [[package]]
 name = "libdd-trace-protobuf"
 version = "3.0.1"
-source = "git+https://github.com/DataDog/libdatadog?rev=4ae8ebe252451374c292efd159ce254c3f5a72e0#4ae8ebe252451374c292efd159ce254c3f5a72e0"
+source = "git+https://github.com/DataDog/libdatadog?rev=0a3304c6aaf84738786b670d706a01edc22dab81#0a3304c6aaf84738786b670d706a01edc22dab81"
 dependencies = [
  "prost 0.14.3",
  "serde",
@@ -1736,16 +1740,17 @@ dependencies = [
 [[package]]
 name = "libdd-trace-stats"
 version = "2.0.0"
-source = "git+https://github.com/DataDog/libdatadog?rev=4ae8ebe252451374c292efd159ce254c3f5a72e0#4ae8ebe252451374c292efd159ce254c3f5a72e0"
+source = "git+https://github.com/DataDog/libdatadog?rev=0a3304c6aaf84738786b670d706a01edc22dab81#0a3304c6aaf84738786b670d706a01edc22dab81"
 dependencies = [
  "anyhow",
+ "arc-swap",
  "async-trait",
  "hashbrown 0.15.5",
  "http",
  "libdd-capabilities",
  "libdd-capabilities-impl",
  "libdd-common 4.0.0",
- "libdd-ddsketch 1.0.1 (git+https://github.com/DataDog/libdatadog?rev=4ae8ebe252451374c292efd159ce254c3f5a72e0)",
+ "libdd-ddsketch 1.0.1 (git+https://github.com/DataDog/libdatadog?rev=0a3304c6aaf84738786b670d706a01edc22dab81)",
  "libdd-shared-runtime",
  "libdd-trace-obfuscation",
  "libdd-trace-protobuf 3.0.1",
@@ -1788,7 +1793,7 @@ dependencies = [
 [[package]]
 name = "libdd-trace-utils"
 version = "3.0.1"
-source = "git+https://github.com/DataDog/libdatadog?rev=4ae8ebe252451374c292efd159ce254c3f5a72e0#4ae8ebe252451374c292efd159ce254c3f5a72e0"
+source = "git+https://github.com/DataDog/libdatadog?rev=0a3304c6aaf84738786b670d706a01edc22dab81#0a3304c6aaf84738786b670d706a01edc22dab81"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -1807,7 +1812,7 @@ dependencies = [
  "libdd-capabilities",
  "libdd-capabilities-impl",
  "libdd-common 4.0.0",
- "libdd-tinybytes 1.1.0 (git+https://github.com/DataDog/libdatadog?rev=4ae8ebe252451374c292efd159ce254c3f5a72e0)",
+ "libdd-tinybytes 1.1.0 (git+https://github.com/DataDog/libdatadog?rev=0a3304c6aaf84738786b670d706a01edc22dab81)",
  "libdd-trace-normalization 2.0.0",
  "libdd-trace-protobuf 3.0.1",
  "prost 0.14.3",

--- a/crates/datadog-agent-config/Cargo.toml
+++ b/crates/datadog-agent-config/Cargo.toml
@@ -6,8 +6,8 @@ license.workspace = true
 
 [dependencies]
 figment = { version = "0.10", default-features = false, features = ["yaml", "env"] }
-libdd-trace-obfuscation = { git = "https://github.com/DataDog/libdatadog", rev = "4ae8ebe252451374c292efd159ce254c3f5a72e0" }
-libdd-trace-utils = { git = "https://github.com/DataDog/libdatadog", rev = "4ae8ebe252451374c292efd159ce254c3f5a72e0" }
+libdd-trace-obfuscation = { git = "https://github.com/DataDog/libdatadog", rev = "0a3304c6aaf84738786b670d706a01edc22dab81" }
+libdd-trace-utils = { git = "https://github.com/DataDog/libdatadog", rev = "0a3304c6aaf84738786b670d706a01edc22dab81" }
 log = { version = "0.4", default-features = false }
 serde = { version = "1.0", default-features = false, features = ["derive"] }
 serde-aux = { version = "4.7", default-features = false }

--- a/crates/datadog-metrics-collector/Cargo.toml
+++ b/crates/datadog-metrics-collector/Cargo.toml
@@ -8,7 +8,7 @@ description = "Collector to read, compute, and submit enhanced metrics in Server
 [dependencies]
 dogstatsd = { path = "../dogstatsd", default-features = true }
 tracing = { version = "0.1", default-features = false }
-libdd-common = { git = "https://github.com/DataDog/libdatadog", rev = "4ae8ebe252451374c292efd159ce254c3f5a72e0", default-features = false }
+libdd-common = { git = "https://github.com/DataDog/libdatadog", rev = "0a3304c6aaf84738786b670d706a01edc22dab81", default-features = false }
 
 [dev-dependencies]
 tokio = { version = "1", default-features = false, features = ["macros", "rt-multi-thread"] }

--- a/crates/datadog-serverless-compat/Cargo.toml
+++ b/crates/datadog-serverless-compat/Cargo.toml
@@ -14,7 +14,7 @@ windows-enhanced-metrics = ["datadog-metrics-collector/windows-enhanced-metrics"
 datadog-logs-agent = { path = "../datadog-logs-agent" }
 datadog-metrics-collector = { path = "../datadog-metrics-collector" }
 datadog-trace-agent = { path = "../datadog-trace-agent" }
-libdd-trace-utils = { git = "https://github.com/DataDog/libdatadog", rev = "4ae8ebe252451374c292efd159ce254c3f5a72e0" }
+libdd-trace-utils = { git = "https://github.com/DataDog/libdatadog", rev = "0a3304c6aaf84738786b670d706a01edc22dab81" }
 datadog-fips = { path = "../datadog-fips", default-features = false }
 dogstatsd = { path = "../dogstatsd", default-features = true }
 reqwest = { version = "0.12.4", default-features = false }

--- a/crates/datadog-trace-agent/Cargo.toml
+++ b/crates/datadog-trace-agent/Cargo.toml
@@ -25,16 +25,16 @@ tracing = { version = "0.1", default-features = false }
 serde = { version = "1.0.145", features = ["derive"] }
 serde_json = "1.0"
 thiserror = { version = "1.0.58", default-features = false }
-libdd-capabilities = { git = "https://github.com/DataDog/libdatadog", rev = "4ae8ebe252451374c292efd159ce254c3f5a72e0" }
-libdd-capabilities-impl = { git = "https://github.com/DataDog/libdatadog", rev = "4ae8ebe252451374c292efd159ce254c3f5a72e0" }
-libdd-common = { git = "https://github.com/DataDog/libdatadog", rev = "4ae8ebe252451374c292efd159ce254c3f5a72e0" }
-libdd-library-config = { git = "https://github.com/DataDog/libdatadog", rev = "4ae8ebe252451374c292efd159ce254c3f5a72e0" }
-libdd-trace-protobuf = { git = "https://github.com/DataDog/libdatadog", rev = "4ae8ebe252451374c292efd159ce254c3f5a72e0" }
-libdd-trace-stats = { git = "https://github.com/DataDog/libdatadog", rev = "4ae8ebe252451374c292efd159ce254c3f5a72e0" }
-libdd-trace-utils = { git = "https://github.com/DataDog/libdatadog", rev = "4ae8ebe252451374c292efd159ce254c3f5a72e0", features = [
+libdd-capabilities = { git = "https://github.com/DataDog/libdatadog", rev = "0a3304c6aaf84738786b670d706a01edc22dab81" }
+libdd-capabilities-impl = { git = "https://github.com/DataDog/libdatadog", rev = "0a3304c6aaf84738786b670d706a01edc22dab81" }
+libdd-common = { git = "https://github.com/DataDog/libdatadog", rev = "0a3304c6aaf84738786b670d706a01edc22dab81" }
+libdd-library-config = { git = "https://github.com/DataDog/libdatadog", rev = "0a3304c6aaf84738786b670d706a01edc22dab81" }
+libdd-trace-protobuf = { git = "https://github.com/DataDog/libdatadog", rev = "0a3304c6aaf84738786b670d706a01edc22dab81" }
+libdd-trace-stats = { git = "https://github.com/DataDog/libdatadog", rev = "0a3304c6aaf84738786b670d706a01edc22dab81" }
+libdd-trace-utils = { git = "https://github.com/DataDog/libdatadog", rev = "0a3304c6aaf84738786b670d706a01edc22dab81", features = [
     "mini_agent",
 ] }
-libdd-trace-obfuscation = { git = "https://github.com/DataDog/libdatadog", rev = "4ae8ebe252451374c292efd159ce254c3f5a72e0" }
+libdd-trace-obfuscation = { git = "https://github.com/DataDog/libdatadog", rev = "0a3304c6aaf84738786b670d706a01edc22dab81" }
 datadog-fips = { path = "../datadog-fips" }
 reqwest = { version = "0.12.23", features = [
     "json",
@@ -49,6 +49,6 @@ serial_test = "2.0.0"
 duplicate = "2.0.1"
 temp-env = "0.3.6"
 tempfile = "3.3.0"
-libdd-trace-utils = { git = "https://github.com/DataDog/libdatadog", rev = "4ae8ebe252451374c292efd159ce254c3f5a72e0", features = [
+libdd-trace-utils = { git = "https://github.com/DataDog/libdatadog", rev = "0a3304c6aaf84738786b670d706a01edc22dab81", features = [
     "test-utils",
 ] }

--- a/crates/datadog-trace-agent/src/stats_flusher.rs
+++ b/crates/datadog-trace-agent/src/stats_flusher.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use async_trait::async_trait;
-use libdd_capabilities_impl::DefaultHttpClient;
+use libdd_capabilities_impl::NativeHttpClient;
 use std::{sync::Arc, time};
 use tokio::sync::mpsc::Receiver;
 use tokio::sync::oneshot;
@@ -25,7 +25,7 @@ async fn send_stats_payload(config: &Arc<Config>, payload: pb::StatsPayload) {
         }
     };
     #[allow(clippy::unwrap_used)]
-    match stats_utils::send_stats_payload::<DefaultHttpClient>(
+    match stats_utils::send_stats_payload::<NativeHttpClient>(
         serialized,
         &config.trace_stats_intake,
         config.trace_stats_intake.api_key.as_ref().unwrap(),

--- a/crates/datadog-trace-agent/src/trace_flusher.rs
+++ b/crates/datadog-trace-agent/src/trace_flusher.rs
@@ -7,8 +7,9 @@ use tokio::sync::{Mutex, mpsc::Receiver};
 use tracing::{debug, error};
 
 use http_body_util::BodyExt;
-use libdd_capabilities::http::{HttpClientTrait, HttpError};
-use libdd_capabilities::{MaybeSend, Request, Response};
+use libdd_capabilities::http::{HttpClientCapability, HttpError};
+use libdd_capabilities::{MaybeSend, Request, Response, SleepCapability};
+use libdd_capabilities_impl::NativeSleepCapability;
 use libdd_common::connector::Connector;
 use libdd_common::http_common::{self, Body, GenericHttpClient};
 use libdd_trace_utils::trace_utils;
@@ -132,7 +133,7 @@ impl ProxyHttpClient {
     }
 }
 
-impl HttpClientTrait for ProxyHttpClient {
+impl HttpClientCapability for ProxyHttpClient {
     #[allow(clippy::expect_used)]
     fn new_client() -> Self {
         Self::with_proxy(None).expect("building proxy connector with default TLS should not fail")
@@ -158,5 +159,19 @@ impl HttpClientTrait for ProxyHttpClient {
                 .to_bytes();
             Ok(Response::from_parts(parts, collected))
         }
+    }
+}
+
+impl SleepCapability for ProxyHttpClient {
+    #[allow(clippy::expect_used)]
+    fn new() -> Self {
+        Self::with_proxy(None).expect("building proxy connector with default TLS should not fail")
+    }
+
+    fn sleep(
+        &self,
+        duration: std::time::Duration,
+    ) -> impl std::future::Future<Output = ()> + MaybeSend {
+        NativeSleepCapability.sleep(duration)
     }
 }


### PR DESCRIPTION
### What does this PR do?

Updates libdatadog revision to https://github.com/DataDog/libdatadog/commit/0a3304c6aaf84738786b670d706a01edc22dab81.

### Motivation

https://datadoghq.atlassian.net/browse/SVLS-9006

### Additional Notes

- Follows https://github.com/DataDog/libdatadog/pull/1954: feat(trace-utils)!: search all spans to populate tracer payload fields.
- Updates some dependencies with breaking changes

### Describe how to test/QA your changes

Invoked .NET functions that undercounted some stats by version and validated that all trace stats submitted to intake have a version.

```
plow "$url" -c 50 -n 50000
```

<img width="1405" height="509" alt="Screenshot 2026-05-15 at 10 02 59 AM" src="https://github.com/user-attachments/assets/881773de-226e-479c-848e-69fb328df8c0" />
<br><br>

With 50% sampling enabled: `DD_TRACE_SAMPLING_RULES: [{"sample_rate":0.5}]`

<img width="1406" height="503" alt="Screenshot 2026-05-15 at 10 08 46 AM" src="https://github.com/user-attachments/assets/3724d455-55a7-4635-bbd5-83dd6b57540c" />

