### PR TITLE
[SVLS-9015] Use consts and instance resolution logic from libdd-common

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -449,6 +449,7 @@ dependencies = [
  "figment",
  "libdd-trace-obfuscation",
  "libdd-trace-utils 6.0.1",
+ "libdd-trace-utils 6.0.1",
  "log",
  "serde",
  "serde-aux",
@@ -493,6 +494,7 @@ version = "0.1.0"
 dependencies = [
  "dogstatsd",
  "libdd-common 4.2.0",
+ "libdd-common 4.2.0",
  "tokio",
  "tracing",
  "windows-sys 0.61.2",
@@ -514,6 +516,7 @@ dependencies = [
  "libdd-common 2.0.1",
  "libdd-data-pipeline",
  "libdd-telemetry",
+ "libdd-tinybytes 1.1.0",
  "libdd-tinybytes 1.1.0",
  "libdd-trace-utils 2.0.2",
  "lru",
@@ -555,6 +558,7 @@ dependencies = [
  "datadog-trace-agent",
  "dogstatsd",
  "libdd-trace-utils 6.0.1",
+ "libdd-trace-utils 6.0.1",
  "reqwest",
  "serde_json",
  "tokio",
@@ -581,8 +585,12 @@ dependencies = [
  "libdd-capabilities",
  "libdd-capabilities-impl",
  "libdd-common 4.2.0",
+ "libdd-common 4.2.0",
  "libdd-library-config",
  "libdd-trace-obfuscation",
+ "libdd-trace-protobuf 3.0.2",
+ "libdd-trace-stats 4.0.0",
+ "libdd-trace-utils 6.0.1",
  "libdd-trace-protobuf 3.0.2",
  "libdd-trace-stats 4.0.0",
  "libdd-trace-utils 6.0.1",
@@ -1447,7 +1455,7 @@ checksum = "b5b646652bf6661599e1da8901b3b9522896f01e736bad5f723fe7a3a27f899d"
 [[package]]
 name = "libdd-capabilities"
 version = "2.0.0"
-source = "git+https://github.com/DataDog/libdatadog?rev=48da0d82cb32b43d4cdece35b794c9bcbc275a03#48da0d82cb32b43d4cdece35b794c9bcbc275a03"
+source = "git+https://github.com/DataDog/libdatadog?rev=62e9d0148219f89fea3aab066235d9c9ddd43767#62e9d0148219f89fea3aab066235d9c9ddd43767"
 dependencies = [
  "anyhow",
  "bytes",
@@ -1458,12 +1466,13 @@ dependencies = [
 [[package]]
 name = "libdd-capabilities-impl"
 version = "2.0.0"
-source = "git+https://github.com/DataDog/libdatadog?rev=48da0d82cb32b43d4cdece35b794c9bcbc275a03#48da0d82cb32b43d4cdece35b794c9bcbc275a03"
+source = "git+https://github.com/DataDog/libdatadog?rev=62e9d0148219f89fea3aab066235d9c9ddd43767#62e9d0148219f89fea3aab066235d9c9ddd43767"
 dependencies = [
  "bytes",
  "http",
  "http-body-util",
  "libdd-capabilities",
+ "libdd-common 4.2.0",
  "libdd-common 4.2.0",
  "tokio",
 ]
@@ -1502,7 +1511,7 @@ dependencies = [
 [[package]]
 name = "libdd-common"
 version = "4.2.0"
-source = "git+https://github.com/DataDog/libdatadog?rev=48da0d82cb32b43d4cdece35b794c9bcbc275a03#48da0d82cb32b43d4cdece35b794c9bcbc275a03"
+source = "git+https://github.com/DataDog/libdatadog?rev=62e9d0148219f89fea3aab066235d9c9ddd43767#62e9d0148219f89fea3aab066235d9c9ddd43767"
 dependencies = [
  "anyhow",
  "bytes",
@@ -1550,6 +1559,7 @@ dependencies = [
  "libdd-dogstatsd-client",
  "libdd-telemetry",
  "libdd-tinybytes 1.1.0",
+ "libdd-tinybytes 1.1.0",
  "libdd-trace-protobuf 2.0.0",
  "libdd-trace-stats 1.0.3",
  "libdd-trace-utils 2.0.2",
@@ -1575,7 +1585,7 @@ dependencies = [
 [[package]]
 name = "libdd-ddsketch"
 version = "1.0.1"
-source = "git+https://github.com/DataDog/libdatadog?rev=48da0d82cb32b43d4cdece35b794c9bcbc275a03#48da0d82cb32b43d4cdece35b794c9bcbc275a03"
+source = "git+https://github.com/DataDog/libdatadog?rev=62e9d0148219f89fea3aab066235d9c9ddd43767#62e9d0148219f89fea3aab066235d9c9ddd43767"
 dependencies = [
  "prost 0.14.3",
 ]
@@ -1597,10 +1607,11 @@ dependencies = [
 [[package]]
 name = "libdd-library-config"
 version = "2.0.0"
-source = "git+https://github.com/DataDog/libdatadog?rev=48da0d82cb32b43d4cdece35b794c9bcbc275a03#48da0d82cb32b43d4cdece35b794c9bcbc275a03"
+source = "git+https://github.com/DataDog/libdatadog?rev=62e9d0148219f89fea3aab066235d9c9ddd43767#62e9d0148219f89fea3aab066235d9c9ddd43767"
 dependencies = [
  "anyhow",
  "libc",
+ "libdd-trace-protobuf 3.0.2",
  "libdd-trace-protobuf 3.0.2",
  "memfd",
  "prost 0.14.3",
@@ -1614,13 +1625,14 @@ dependencies = [
 [[package]]
 name = "libdd-shared-runtime"
 version = "1.0.0"
-source = "git+https://github.com/DataDog/libdatadog?rev=48da0d82cb32b43d4cdece35b794c9bcbc275a03#48da0d82cb32b43d4cdece35b794c9bcbc275a03"
+source = "git+https://github.com/DataDog/libdatadog?rev=62e9d0148219f89fea3aab066235d9c9ddd43767#62e9d0148219f89fea3aab066235d9c9ddd43767"
 dependencies = [
  "async-trait",
  "futures",
  "futures-util",
  "libdd-capabilities",
  "libdd-capabilities-impl",
+ "libdd-common 4.2.0",
  "libdd-common 4.2.0",
  "tokio",
  "tokio-util",
@@ -1665,7 +1677,7 @@ dependencies = [
 [[package]]
 name = "libdd-tinybytes"
 version = "1.1.1"
-source = "git+https://github.com/DataDog/libdatadog?rev=48da0d82cb32b43d4cdece35b794c9bcbc275a03#48da0d82cb32b43d4cdece35b794c9bcbc275a03"
+source = "git+https://github.com/DataDog/libdatadog?rev=62e9d0148219f89fea3aab066235d9c9ddd43767#62e9d0148219f89fea3aab066235d9c9ddd43767"
 dependencies = [
  "serde",
 ]
@@ -1683,19 +1695,23 @@ dependencies = [
 [[package]]
 name = "libdd-trace-normalization"
 version = "2.0.0"
-source = "git+https://github.com/DataDog/libdatadog?rev=48da0d82cb32b43d4cdece35b794c9bcbc275a03#48da0d82cb32b43d4cdece35b794c9bcbc275a03"
+source = "git+https://github.com/DataDog/libdatadog?rev=62e9d0148219f89fea3aab066235d9c9ddd43767#62e9d0148219f89fea3aab066235d9c9ddd43767"
 dependencies = [
  "anyhow",
+ "libdd-trace-protobuf 3.0.2",
  "libdd-trace-protobuf 3.0.2",
 ]
 
 [[package]]
 name = "libdd-trace-obfuscation"
 version = "3.1.0"
-source = "git+https://github.com/DataDog/libdatadog?rev=48da0d82cb32b43d4cdece35b794c9bcbc275a03#48da0d82cb32b43d4cdece35b794c9bcbc275a03"
+source = "git+https://github.com/DataDog/libdatadog?rev=62e9d0148219f89fea3aab066235d9c9ddd43767#62e9d0148219f89fea3aab066235d9c9ddd43767"
 dependencies = [
  "anyhow",
  "fluent-uri",
+ "libdd-common 4.2.0",
+ "libdd-trace-protobuf 3.0.2",
+ "libdd-trace-utils 6.0.1",
  "libdd-common 4.2.0",
  "libdd-trace-protobuf 3.0.2",
  "libdd-trace-utils 6.0.1",
@@ -1719,7 +1735,7 @@ dependencies = [
 [[package]]
 name = "libdd-trace-protobuf"
 version = "3.0.2"
-source = "git+https://github.com/DataDog/libdatadog?rev=48da0d82cb32b43d4cdece35b794c9bcbc275a03#48da0d82cb32b43d4cdece35b794c9bcbc275a03"
+source = "git+https://github.com/DataDog/libdatadog?rev=62e9d0148219f89fea3aab066235d9c9ddd43767#62e9d0148219f89fea3aab066235d9c9ddd43767"
 dependencies = [
  "prost 0.14.3",
  "serde",
@@ -1741,7 +1757,7 @@ dependencies = [
 [[package]]
 name = "libdd-trace-stats"
 version = "4.0.0"
-source = "git+https://github.com/DataDog/libdatadog?rev=48da0d82cb32b43d4cdece35b794c9bcbc275a03#48da0d82cb32b43d4cdece35b794c9bcbc275a03"
+source = "git+https://github.com/DataDog/libdatadog?rev=62e9d0148219f89fea3aab066235d9c9ddd43767#62e9d0148219f89fea3aab066235d9c9ddd43767"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -1751,9 +1767,11 @@ dependencies = [
  "libdd-capabilities",
  "libdd-capabilities-impl",
  "libdd-common 4.2.0",
- "libdd-ddsketch 1.0.1 (git+https://github.com/DataDog/libdatadog?rev=48da0d82cb32b43d4cdece35b794c9bcbc275a03)",
+ "libdd-ddsketch 1.0.1 (git+https://github.com/DataDog/libdatadog?rev=62e9d0148219f89fea3aab066235d9c9ddd43767)",
  "libdd-shared-runtime",
  "libdd-trace-obfuscation",
+ "libdd-trace-protobuf 3.0.2",
+ "libdd-trace-utils 6.0.1",
  "libdd-trace-protobuf 3.0.2",
  "libdd-trace-utils 6.0.1",
  "rmp-serde",
@@ -1778,6 +1796,7 @@ dependencies = [
  "indexmap",
  "libdd-common 2.0.1",
  "libdd-tinybytes 1.1.0",
+ "libdd-tinybytes 1.1.0",
  "libdd-trace-normalization 1.0.2",
  "libdd-trace-protobuf 2.0.0",
  "prost 0.14.3",
@@ -1794,7 +1813,7 @@ dependencies = [
 [[package]]
 name = "libdd-trace-utils"
 version = "6.0.1"
-source = "git+https://github.com/DataDog/libdatadog?rev=48da0d82cb32b43d4cdece35b794c9bcbc275a03#48da0d82cb32b43d4cdece35b794c9bcbc275a03"
+source = "git+https://github.com/DataDog/libdatadog?rev=62e9d0148219f89fea3aab066235d9c9ddd43767#62e9d0148219f89fea3aab066235d9c9ddd43767"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -1814,7 +1833,10 @@ dependencies = [
  "libdd-capabilities-impl",
  "libdd-common 4.2.0",
  "libdd-tinybytes 1.1.1",
+ "libdd-common 4.2.0",
+ "libdd-tinybytes 1.1.1",
  "libdd-trace-normalization 2.0.0",
+ "libdd-trace-protobuf 3.0.2",
  "libdd-trace-protobuf 3.0.2",
  "prost 0.14.3",
  "rand 0.8.6",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -493,7 +493,6 @@ version = "0.1.0"
 dependencies = [
  "dogstatsd",
  "libdd-common 4.2.0",
- "libdd-common 4.2.0",
  "tokio",
  "tracing",
  "windows-sys 0.61.2",
@@ -515,7 +514,6 @@ dependencies = [
  "libdd-common 2.0.1",
  "libdd-data-pipeline",
  "libdd-telemetry",
- "libdd-tinybytes 1.1.0",
  "libdd-tinybytes 1.1.0",
  "libdd-trace-utils 2.0.2",
  "lru",
@@ -582,7 +580,6 @@ dependencies = [
  "hyper-util",
  "libdd-capabilities",
  "libdd-capabilities-impl",
- "libdd-common 4.2.0",
  "libdd-common 4.2.0",
  "libdd-library-config",
  "libdd-trace-obfuscation",
@@ -1468,7 +1465,6 @@ dependencies = [
  "http-body-util",
  "libdd-capabilities",
  "libdd-common 4.2.0",
- "libdd-common 4.2.0",
  "tokio",
 ]
 
@@ -1554,7 +1550,6 @@ dependencies = [
  "libdd-dogstatsd-client",
  "libdd-telemetry",
  "libdd-tinybytes 1.1.0",
- "libdd-tinybytes 1.1.0",
  "libdd-trace-protobuf 2.0.0",
  "libdd-trace-stats 1.0.3",
  "libdd-trace-utils 2.0.2",
@@ -1607,7 +1602,6 @@ dependencies = [
  "anyhow",
  "libc",
  "libdd-trace-protobuf 3.0.2",
- "libdd-trace-protobuf 3.0.2",
  "memfd",
  "prost 0.14.3",
  "rand 0.8.6",
@@ -1627,7 +1621,6 @@ dependencies = [
  "futures-util",
  "libdd-capabilities",
  "libdd-capabilities-impl",
- "libdd-common 4.2.0",
  "libdd-common 4.2.0",
  "tokio",
  "tokio-util",
@@ -1693,7 +1686,6 @@ version = "2.0.0"
 source = "git+https://github.com/DataDog/libdatadog?rev=a820699426f28cbabb3a74d87c7309d030b52e7c#a820699426f28cbabb3a74d87c7309d030b52e7c"
 dependencies = [
  "anyhow",
- "libdd-trace-protobuf 3.0.2",
  "libdd-trace-protobuf 3.0.2",
 ]
 
@@ -1786,7 +1778,6 @@ dependencies = [
  "indexmap",
  "libdd-common 2.0.1",
  "libdd-tinybytes 1.1.0",
- "libdd-tinybytes 1.1.0",
  "libdd-trace-normalization 1.0.2",
  "libdd-trace-protobuf 2.0.0",
  "prost 0.14.3",
@@ -1823,10 +1814,7 @@ dependencies = [
  "libdd-capabilities-impl",
  "libdd-common 4.2.0",
  "libdd-tinybytes 1.1.1",
- "libdd-common 4.2.0",
- "libdd-tinybytes 1.1.1",
  "libdd-trace-normalization 2.0.0",
- "libdd-trace-protobuf 3.0.2",
  "libdd-trace-protobuf 3.0.2",
  "prost 0.14.3",
  "rand 0.8.6",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -448,7 +448,7 @@ dependencies = [
  "dogstatsd",
  "figment",
  "libdd-trace-obfuscation",
- "libdd-trace-utils 7.0.0",
+ "libdd-trace-utils 8.0.0",
  "log",
  "serde",
  "serde-aux",
@@ -556,7 +556,7 @@ dependencies = [
  "datadog-metrics-collector",
  "datadog-trace-agent",
  "dogstatsd",
- "libdd-trace-utils 7.0.0",
+ "libdd-trace-utils 8.0.0",
  "reqwest",
  "serde_json",
  "tokio",
@@ -587,8 +587,8 @@ dependencies = [
  "libdd-library-config",
  "libdd-trace-obfuscation",
  "libdd-trace-protobuf 3.0.2",
- "libdd-trace-stats 4.0.0",
- "libdd-trace-utils 7.0.0",
+ "libdd-trace-stats 5.0.0",
+ "libdd-trace-utils 8.0.0",
  "reqwest",
  "rmp-serde",
  "serde",
@@ -1450,7 +1450,7 @@ checksum = "b5b646652bf6661599e1da8901b3b9522896f01e736bad5f723fe7a3a27f899d"
 [[package]]
 name = "libdd-capabilities"
 version = "2.0.0"
-source = "git+https://github.com/DataDog/libdatadog?rev=869d5709ec35410ab42c94a5904cdc8deec93bdf#869d5709ec35410ab42c94a5904cdc8deec93bdf"
+source = "git+https://github.com/DataDog/libdatadog?rev=a820699426f28cbabb3a74d87c7309d030b52e7c#a820699426f28cbabb3a74d87c7309d030b52e7c"
 dependencies = [
  "anyhow",
  "bytes",
@@ -1461,7 +1461,7 @@ dependencies = [
 [[package]]
 name = "libdd-capabilities-impl"
 version = "2.0.0"
-source = "git+https://github.com/DataDog/libdatadog?rev=869d5709ec35410ab42c94a5904cdc8deec93bdf#869d5709ec35410ab42c94a5904cdc8deec93bdf"
+source = "git+https://github.com/DataDog/libdatadog?rev=a820699426f28cbabb3a74d87c7309d030b52e7c#a820699426f28cbabb3a74d87c7309d030b52e7c"
 dependencies = [
  "bytes",
  "http",
@@ -1506,7 +1506,7 @@ dependencies = [
 [[package]]
 name = "libdd-common"
 version = "4.2.0"
-source = "git+https://github.com/DataDog/libdatadog?rev=869d5709ec35410ab42c94a5904cdc8deec93bdf#869d5709ec35410ab42c94a5904cdc8deec93bdf"
+source = "git+https://github.com/DataDog/libdatadog?rev=a820699426f28cbabb3a74d87c7309d030b52e7c#a820699426f28cbabb3a74d87c7309d030b52e7c"
 dependencies = [
  "anyhow",
  "bytes",
@@ -1580,7 +1580,7 @@ dependencies = [
 [[package]]
 name = "libdd-ddsketch"
 version = "1.0.1"
-source = "git+https://github.com/DataDog/libdatadog?rev=869d5709ec35410ab42c94a5904cdc8deec93bdf#869d5709ec35410ab42c94a5904cdc8deec93bdf"
+source = "git+https://github.com/DataDog/libdatadog?rev=a820699426f28cbabb3a74d87c7309d030b52e7c#a820699426f28cbabb3a74d87c7309d030b52e7c"
 dependencies = [
  "prost 0.14.3",
 ]
@@ -1602,7 +1602,7 @@ dependencies = [
 [[package]]
 name = "libdd-library-config"
 version = "2.0.0"
-source = "git+https://github.com/DataDog/libdatadog?rev=869d5709ec35410ab42c94a5904cdc8deec93bdf#869d5709ec35410ab42c94a5904cdc8deec93bdf"
+source = "git+https://github.com/DataDog/libdatadog?rev=a820699426f28cbabb3a74d87c7309d030b52e7c#a820699426f28cbabb3a74d87c7309d030b52e7c"
 dependencies = [
  "anyhow",
  "libc",
@@ -1620,7 +1620,7 @@ dependencies = [
 [[package]]
 name = "libdd-shared-runtime"
 version = "1.0.0"
-source = "git+https://github.com/DataDog/libdatadog?rev=869d5709ec35410ab42c94a5904cdc8deec93bdf#869d5709ec35410ab42c94a5904cdc8deec93bdf"
+source = "git+https://github.com/DataDog/libdatadog?rev=a820699426f28cbabb3a74d87c7309d030b52e7c#a820699426f28cbabb3a74d87c7309d030b52e7c"
 dependencies = [
  "async-trait",
  "futures",
@@ -1672,7 +1672,7 @@ dependencies = [
 [[package]]
 name = "libdd-tinybytes"
 version = "1.1.1"
-source = "git+https://github.com/DataDog/libdatadog?rev=869d5709ec35410ab42c94a5904cdc8deec93bdf#869d5709ec35410ab42c94a5904cdc8deec93bdf"
+source = "git+https://github.com/DataDog/libdatadog?rev=a820699426f28cbabb3a74d87c7309d030b52e7c#a820699426f28cbabb3a74d87c7309d030b52e7c"
 dependencies = [
  "serde",
 ]
@@ -1690,7 +1690,7 @@ dependencies = [
 [[package]]
 name = "libdd-trace-normalization"
 version = "2.0.0"
-source = "git+https://github.com/DataDog/libdatadog?rev=869d5709ec35410ab42c94a5904cdc8deec93bdf#869d5709ec35410ab42c94a5904cdc8deec93bdf"
+source = "git+https://github.com/DataDog/libdatadog?rev=a820699426f28cbabb3a74d87c7309d030b52e7c#a820699426f28cbabb3a74d87c7309d030b52e7c"
 dependencies = [
  "anyhow",
  "libdd-trace-protobuf 3.0.2",
@@ -1699,14 +1699,14 @@ dependencies = [
 
 [[package]]
 name = "libdd-trace-obfuscation"
-version = "3.1.0"
-source = "git+https://github.com/DataDog/libdatadog?rev=869d5709ec35410ab42c94a5904cdc8deec93bdf#869d5709ec35410ab42c94a5904cdc8deec93bdf"
+version = "4.0.0"
+source = "git+https://github.com/DataDog/libdatadog?rev=a820699426f28cbabb3a74d87c7309d030b52e7c#a820699426f28cbabb3a74d87c7309d030b52e7c"
 dependencies = [
  "anyhow",
  "fluent-uri",
  "libdd-common 4.2.0",
  "libdd-trace-protobuf 3.0.2",
- "libdd-trace-utils 7.0.0",
+ "libdd-trace-utils 8.0.0",
  "log",
  "percent-encoding",
  "serde",
@@ -1727,7 +1727,7 @@ dependencies = [
 [[package]]
 name = "libdd-trace-protobuf"
 version = "3.0.2"
-source = "git+https://github.com/DataDog/libdatadog?rev=869d5709ec35410ab42c94a5904cdc8deec93bdf#869d5709ec35410ab42c94a5904cdc8deec93bdf"
+source = "git+https://github.com/DataDog/libdatadog?rev=a820699426f28cbabb3a74d87c7309d030b52e7c#a820699426f28cbabb3a74d87c7309d030b52e7c"
 dependencies = [
  "prost 0.14.3",
  "serde",
@@ -1748,8 +1748,8 @@ dependencies = [
 
 [[package]]
 name = "libdd-trace-stats"
-version = "4.0.0"
-source = "git+https://github.com/DataDog/libdatadog?rev=869d5709ec35410ab42c94a5904cdc8deec93bdf#869d5709ec35410ab42c94a5904cdc8deec93bdf"
+version = "5.0.0"
+source = "git+https://github.com/DataDog/libdatadog?rev=a820699426f28cbabb3a74d87c7309d030b52e7c#a820699426f28cbabb3a74d87c7309d030b52e7c"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -1759,11 +1759,11 @@ dependencies = [
  "libdd-capabilities",
  "libdd-capabilities-impl",
  "libdd-common 4.2.0",
- "libdd-ddsketch 1.0.1 (git+https://github.com/DataDog/libdatadog?rev=869d5709ec35410ab42c94a5904cdc8deec93bdf)",
+ "libdd-ddsketch 1.0.1 (git+https://github.com/DataDog/libdatadog?rev=a820699426f28cbabb3a74d87c7309d030b52e7c)",
  "libdd-shared-runtime",
  "libdd-trace-obfuscation",
  "libdd-trace-protobuf 3.0.2",
- "libdd-trace-utils 7.0.0",
+ "libdd-trace-utils 8.0.0",
  "rmp-serde",
  "serde",
  "tokio",
@@ -1802,8 +1802,8 @@ dependencies = [
 
 [[package]]
 name = "libdd-trace-utils"
-version = "7.0.0"
-source = "git+https://github.com/DataDog/libdatadog?rev=869d5709ec35410ab42c94a5904cdc8deec93bdf#869d5709ec35410ab42c94a5904cdc8deec93bdf"
+version = "8.0.0"
+source = "git+https://github.com/DataDog/libdatadog?rev=a820699426f28cbabb3a74d87c7309d030b52e7c#a820699426f28cbabb3a74d87c7309d030b52e7c"
 dependencies = [
  "anyhow",
  "base64 0.22.1",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -448,8 +448,7 @@ dependencies = [
  "dogstatsd",
  "figment",
  "libdd-trace-obfuscation",
- "libdd-trace-utils 6.0.1",
- "libdd-trace-utils 6.0.1",
+ "libdd-trace-utils 7.0.0",
  "log",
  "serde",
  "serde-aux",
@@ -557,8 +556,7 @@ dependencies = [
  "datadog-metrics-collector",
  "datadog-trace-agent",
  "dogstatsd",
- "libdd-trace-utils 6.0.1",
- "libdd-trace-utils 6.0.1",
+ "libdd-trace-utils 7.0.0",
  "reqwest",
  "serde_json",
  "tokio",
@@ -590,10 +588,7 @@ dependencies = [
  "libdd-trace-obfuscation",
  "libdd-trace-protobuf 3.0.2",
  "libdd-trace-stats 4.0.0",
- "libdd-trace-utils 6.0.1",
- "libdd-trace-protobuf 3.0.2",
- "libdd-trace-stats 4.0.0",
- "libdd-trace-utils 6.0.1",
+ "libdd-trace-utils 7.0.0",
  "reqwest",
  "rmp-serde",
  "serde",
@@ -1455,7 +1450,7 @@ checksum = "b5b646652bf6661599e1da8901b3b9522896f01e736bad5f723fe7a3a27f899d"
 [[package]]
 name = "libdd-capabilities"
 version = "2.0.0"
-source = "git+https://github.com/DataDog/libdatadog?rev=fcdcb31d3e4871feb25df4f092b7224fdfa10c0d#fcdcb31d3e4871feb25df4f092b7224fdfa10c0d"
+source = "git+https://github.com/DataDog/libdatadog?rev=869d5709ec35410ab42c94a5904cdc8deec93bdf#869d5709ec35410ab42c94a5904cdc8deec93bdf"
 dependencies = [
  "anyhow",
  "bytes",
@@ -1466,7 +1461,7 @@ dependencies = [
 [[package]]
 name = "libdd-capabilities-impl"
 version = "2.0.0"
-source = "git+https://github.com/DataDog/libdatadog?rev=fcdcb31d3e4871feb25df4f092b7224fdfa10c0d#fcdcb31d3e4871feb25df4f092b7224fdfa10c0d"
+source = "git+https://github.com/DataDog/libdatadog?rev=869d5709ec35410ab42c94a5904cdc8deec93bdf#869d5709ec35410ab42c94a5904cdc8deec93bdf"
 dependencies = [
  "bytes",
  "http",
@@ -1511,7 +1506,7 @@ dependencies = [
 [[package]]
 name = "libdd-common"
 version = "4.2.0"
-source = "git+https://github.com/DataDog/libdatadog?rev=fcdcb31d3e4871feb25df4f092b7224fdfa10c0d#fcdcb31d3e4871feb25df4f092b7224fdfa10c0d"
+source = "git+https://github.com/DataDog/libdatadog?rev=869d5709ec35410ab42c94a5904cdc8deec93bdf#869d5709ec35410ab42c94a5904cdc8deec93bdf"
 dependencies = [
  "anyhow",
  "bytes",
@@ -1585,7 +1580,7 @@ dependencies = [
 [[package]]
 name = "libdd-ddsketch"
 version = "1.0.1"
-source = "git+https://github.com/DataDog/libdatadog?rev=fcdcb31d3e4871feb25df4f092b7224fdfa10c0d#fcdcb31d3e4871feb25df4f092b7224fdfa10c0d"
+source = "git+https://github.com/DataDog/libdatadog?rev=869d5709ec35410ab42c94a5904cdc8deec93bdf#869d5709ec35410ab42c94a5904cdc8deec93bdf"
 dependencies = [
  "prost 0.14.3",
 ]
@@ -1607,7 +1602,7 @@ dependencies = [
 [[package]]
 name = "libdd-library-config"
 version = "2.0.0"
-source = "git+https://github.com/DataDog/libdatadog?rev=fcdcb31d3e4871feb25df4f092b7224fdfa10c0d#fcdcb31d3e4871feb25df4f092b7224fdfa10c0d"
+source = "git+https://github.com/DataDog/libdatadog?rev=869d5709ec35410ab42c94a5904cdc8deec93bdf#869d5709ec35410ab42c94a5904cdc8deec93bdf"
 dependencies = [
  "anyhow",
  "libc",
@@ -1625,7 +1620,7 @@ dependencies = [
 [[package]]
 name = "libdd-shared-runtime"
 version = "1.0.0"
-source = "git+https://github.com/DataDog/libdatadog?rev=fcdcb31d3e4871feb25df4f092b7224fdfa10c0d#fcdcb31d3e4871feb25df4f092b7224fdfa10c0d"
+source = "git+https://github.com/DataDog/libdatadog?rev=869d5709ec35410ab42c94a5904cdc8deec93bdf#869d5709ec35410ab42c94a5904cdc8deec93bdf"
 dependencies = [
  "async-trait",
  "futures",
@@ -1677,7 +1672,7 @@ dependencies = [
 [[package]]
 name = "libdd-tinybytes"
 version = "1.1.1"
-source = "git+https://github.com/DataDog/libdatadog?rev=fcdcb31d3e4871feb25df4f092b7224fdfa10c0d#fcdcb31d3e4871feb25df4f092b7224fdfa10c0d"
+source = "git+https://github.com/DataDog/libdatadog?rev=869d5709ec35410ab42c94a5904cdc8deec93bdf#869d5709ec35410ab42c94a5904cdc8deec93bdf"
 dependencies = [
  "serde",
 ]
@@ -1695,7 +1690,7 @@ dependencies = [
 [[package]]
 name = "libdd-trace-normalization"
 version = "2.0.0"
-source = "git+https://github.com/DataDog/libdatadog?rev=fcdcb31d3e4871feb25df4f092b7224fdfa10c0d#fcdcb31d3e4871feb25df4f092b7224fdfa10c0d"
+source = "git+https://github.com/DataDog/libdatadog?rev=869d5709ec35410ab42c94a5904cdc8deec93bdf#869d5709ec35410ab42c94a5904cdc8deec93bdf"
 dependencies = [
  "anyhow",
  "libdd-trace-protobuf 3.0.2",
@@ -1705,16 +1700,13 @@ dependencies = [
 [[package]]
 name = "libdd-trace-obfuscation"
 version = "3.1.0"
-source = "git+https://github.com/DataDog/libdatadog?rev=fcdcb31d3e4871feb25df4f092b7224fdfa10c0d#fcdcb31d3e4871feb25df4f092b7224fdfa10c0d"
+source = "git+https://github.com/DataDog/libdatadog?rev=869d5709ec35410ab42c94a5904cdc8deec93bdf#869d5709ec35410ab42c94a5904cdc8deec93bdf"
 dependencies = [
  "anyhow",
  "fluent-uri",
  "libdd-common 4.2.0",
  "libdd-trace-protobuf 3.0.2",
- "libdd-trace-utils 6.0.1",
- "libdd-common 4.2.0",
- "libdd-trace-protobuf 3.0.2",
- "libdd-trace-utils 6.0.1",
+ "libdd-trace-utils 7.0.0",
  "log",
  "percent-encoding",
  "serde",
@@ -1735,7 +1727,7 @@ dependencies = [
 [[package]]
 name = "libdd-trace-protobuf"
 version = "3.0.2"
-source = "git+https://github.com/DataDog/libdatadog?rev=fcdcb31d3e4871feb25df4f092b7224fdfa10c0d#fcdcb31d3e4871feb25df4f092b7224fdfa10c0d"
+source = "git+https://github.com/DataDog/libdatadog?rev=869d5709ec35410ab42c94a5904cdc8deec93bdf#869d5709ec35410ab42c94a5904cdc8deec93bdf"
 dependencies = [
  "prost 0.14.3",
  "serde",
@@ -1757,7 +1749,7 @@ dependencies = [
 [[package]]
 name = "libdd-trace-stats"
 version = "4.0.0"
-source = "git+https://github.com/DataDog/libdatadog?rev=fcdcb31d3e4871feb25df4f092b7224fdfa10c0d#fcdcb31d3e4871feb25df4f092b7224fdfa10c0d"
+source = "git+https://github.com/DataDog/libdatadog?rev=869d5709ec35410ab42c94a5904cdc8deec93bdf#869d5709ec35410ab42c94a5904cdc8deec93bdf"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -1767,13 +1759,11 @@ dependencies = [
  "libdd-capabilities",
  "libdd-capabilities-impl",
  "libdd-common 4.2.0",
- "libdd-ddsketch 1.0.1 (git+https://github.com/DataDog/libdatadog?rev=fcdcb31d3e4871feb25df4f092b7224fdfa10c0d)",
+ "libdd-ddsketch 1.0.1 (git+https://github.com/DataDog/libdatadog?rev=869d5709ec35410ab42c94a5904cdc8deec93bdf)",
  "libdd-shared-runtime",
  "libdd-trace-obfuscation",
  "libdd-trace-protobuf 3.0.2",
- "libdd-trace-utils 6.0.1",
- "libdd-trace-protobuf 3.0.2",
- "libdd-trace-utils 6.0.1",
+ "libdd-trace-utils 7.0.0",
  "rmp-serde",
  "serde",
  "tokio",
@@ -1812,8 +1802,8 @@ dependencies = [
 
 [[package]]
 name = "libdd-trace-utils"
-version = "6.0.1"
-source = "git+https://github.com/DataDog/libdatadog?rev=fcdcb31d3e4871feb25df4f092b7224fdfa10c0d#fcdcb31d3e4871feb25df4f092b7224fdfa10c0d"
+version = "7.0.0"
+source = "git+https://github.com/DataDog/libdatadog?rev=869d5709ec35410ab42c94a5904cdc8deec93bdf#869d5709ec35410ab42c94a5904cdc8deec93bdf"
 dependencies = [
  "anyhow",
  "base64 0.22.1",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1455,7 +1455,7 @@ checksum = "b5b646652bf6661599e1da8901b3b9522896f01e736bad5f723fe7a3a27f899d"
 [[package]]
 name = "libdd-capabilities"
 version = "2.0.0"
-source = "git+https://github.com/DataDog/libdatadog?rev=62e9d0148219f89fea3aab066235d9c9ddd43767#62e9d0148219f89fea3aab066235d9c9ddd43767"
+source = "git+https://github.com/DataDog/libdatadog?rev=fcdcb31d3e4871feb25df4f092b7224fdfa10c0d#fcdcb31d3e4871feb25df4f092b7224fdfa10c0d"
 dependencies = [
  "anyhow",
  "bytes",
@@ -1466,7 +1466,7 @@ dependencies = [
 [[package]]
 name = "libdd-capabilities-impl"
 version = "2.0.0"
-source = "git+https://github.com/DataDog/libdatadog?rev=62e9d0148219f89fea3aab066235d9c9ddd43767#62e9d0148219f89fea3aab066235d9c9ddd43767"
+source = "git+https://github.com/DataDog/libdatadog?rev=fcdcb31d3e4871feb25df4f092b7224fdfa10c0d#fcdcb31d3e4871feb25df4f092b7224fdfa10c0d"
 dependencies = [
  "bytes",
  "http",
@@ -1511,7 +1511,7 @@ dependencies = [
 [[package]]
 name = "libdd-common"
 version = "4.2.0"
-source = "git+https://github.com/DataDog/libdatadog?rev=62e9d0148219f89fea3aab066235d9c9ddd43767#62e9d0148219f89fea3aab066235d9c9ddd43767"
+source = "git+https://github.com/DataDog/libdatadog?rev=fcdcb31d3e4871feb25df4f092b7224fdfa10c0d#fcdcb31d3e4871feb25df4f092b7224fdfa10c0d"
 dependencies = [
  "anyhow",
  "bytes",
@@ -1585,7 +1585,7 @@ dependencies = [
 [[package]]
 name = "libdd-ddsketch"
 version = "1.0.1"
-source = "git+https://github.com/DataDog/libdatadog?rev=62e9d0148219f89fea3aab066235d9c9ddd43767#62e9d0148219f89fea3aab066235d9c9ddd43767"
+source = "git+https://github.com/DataDog/libdatadog?rev=fcdcb31d3e4871feb25df4f092b7224fdfa10c0d#fcdcb31d3e4871feb25df4f092b7224fdfa10c0d"
 dependencies = [
  "prost 0.14.3",
 ]
@@ -1607,7 +1607,7 @@ dependencies = [
 [[package]]
 name = "libdd-library-config"
 version = "2.0.0"
-source = "git+https://github.com/DataDog/libdatadog?rev=62e9d0148219f89fea3aab066235d9c9ddd43767#62e9d0148219f89fea3aab066235d9c9ddd43767"
+source = "git+https://github.com/DataDog/libdatadog?rev=fcdcb31d3e4871feb25df4f092b7224fdfa10c0d#fcdcb31d3e4871feb25df4f092b7224fdfa10c0d"
 dependencies = [
  "anyhow",
  "libc",
@@ -1625,7 +1625,7 @@ dependencies = [
 [[package]]
 name = "libdd-shared-runtime"
 version = "1.0.0"
-source = "git+https://github.com/DataDog/libdatadog?rev=62e9d0148219f89fea3aab066235d9c9ddd43767#62e9d0148219f89fea3aab066235d9c9ddd43767"
+source = "git+https://github.com/DataDog/libdatadog?rev=fcdcb31d3e4871feb25df4f092b7224fdfa10c0d#fcdcb31d3e4871feb25df4f092b7224fdfa10c0d"
 dependencies = [
  "async-trait",
  "futures",
@@ -1677,7 +1677,7 @@ dependencies = [
 [[package]]
 name = "libdd-tinybytes"
 version = "1.1.1"
-source = "git+https://github.com/DataDog/libdatadog?rev=62e9d0148219f89fea3aab066235d9c9ddd43767#62e9d0148219f89fea3aab066235d9c9ddd43767"
+source = "git+https://github.com/DataDog/libdatadog?rev=fcdcb31d3e4871feb25df4f092b7224fdfa10c0d#fcdcb31d3e4871feb25df4f092b7224fdfa10c0d"
 dependencies = [
  "serde",
 ]
@@ -1695,7 +1695,7 @@ dependencies = [
 [[package]]
 name = "libdd-trace-normalization"
 version = "2.0.0"
-source = "git+https://github.com/DataDog/libdatadog?rev=62e9d0148219f89fea3aab066235d9c9ddd43767#62e9d0148219f89fea3aab066235d9c9ddd43767"
+source = "git+https://github.com/DataDog/libdatadog?rev=fcdcb31d3e4871feb25df4f092b7224fdfa10c0d#fcdcb31d3e4871feb25df4f092b7224fdfa10c0d"
 dependencies = [
  "anyhow",
  "libdd-trace-protobuf 3.0.2",
@@ -1705,7 +1705,7 @@ dependencies = [
 [[package]]
 name = "libdd-trace-obfuscation"
 version = "3.1.0"
-source = "git+https://github.com/DataDog/libdatadog?rev=62e9d0148219f89fea3aab066235d9c9ddd43767#62e9d0148219f89fea3aab066235d9c9ddd43767"
+source = "git+https://github.com/DataDog/libdatadog?rev=fcdcb31d3e4871feb25df4f092b7224fdfa10c0d#fcdcb31d3e4871feb25df4f092b7224fdfa10c0d"
 dependencies = [
  "anyhow",
  "fluent-uri",
@@ -1735,7 +1735,7 @@ dependencies = [
 [[package]]
 name = "libdd-trace-protobuf"
 version = "3.0.2"
-source = "git+https://github.com/DataDog/libdatadog?rev=62e9d0148219f89fea3aab066235d9c9ddd43767#62e9d0148219f89fea3aab066235d9c9ddd43767"
+source = "git+https://github.com/DataDog/libdatadog?rev=fcdcb31d3e4871feb25df4f092b7224fdfa10c0d#fcdcb31d3e4871feb25df4f092b7224fdfa10c0d"
 dependencies = [
  "prost 0.14.3",
  "serde",
@@ -1757,7 +1757,7 @@ dependencies = [
 [[package]]
 name = "libdd-trace-stats"
 version = "4.0.0"
-source = "git+https://github.com/DataDog/libdatadog?rev=62e9d0148219f89fea3aab066235d9c9ddd43767#62e9d0148219f89fea3aab066235d9c9ddd43767"
+source = "git+https://github.com/DataDog/libdatadog?rev=fcdcb31d3e4871feb25df4f092b7224fdfa10c0d#fcdcb31d3e4871feb25df4f092b7224fdfa10c0d"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -1767,7 +1767,7 @@ dependencies = [
  "libdd-capabilities",
  "libdd-capabilities-impl",
  "libdd-common 4.2.0",
- "libdd-ddsketch 1.0.1 (git+https://github.com/DataDog/libdatadog?rev=62e9d0148219f89fea3aab066235d9c9ddd43767)",
+ "libdd-ddsketch 1.0.1 (git+https://github.com/DataDog/libdatadog?rev=fcdcb31d3e4871feb25df4f092b7224fdfa10c0d)",
  "libdd-shared-runtime",
  "libdd-trace-obfuscation",
  "libdd-trace-protobuf 3.0.2",
@@ -1813,7 +1813,7 @@ dependencies = [
 [[package]]
 name = "libdd-trace-utils"
 version = "6.0.1"
-source = "git+https://github.com/DataDog/libdatadog?rev=62e9d0148219f89fea3aab066235d9c9ddd43767#62e9d0148219f89fea3aab066235d9c9ddd43767"
+source = "git+https://github.com/DataDog/libdatadog?rev=fcdcb31d3e4871feb25df4f092b7224fdfa10c0d#fcdcb31d3e4871feb25df4f092b7224fdfa10c0d"
 dependencies = [
  "anyhow",
  "base64 0.22.1",

--- a/crates/datadog-agent-config/Cargo.toml
+++ b/crates/datadog-agent-config/Cargo.toml
@@ -6,8 +6,8 @@ license.workspace = true
 
 [dependencies]
 figment = { version = "0.10", default-features = false, features = ["yaml", "env"] }
-libdd-trace-obfuscation = { git = "https://github.com/DataDog/libdatadog", rev = "62e9d0148219f89fea3aab066235d9c9ddd43767" }
-libdd-trace-utils = { git = "https://github.com/DataDog/libdatadog", rev = "62e9d0148219f89fea3aab066235d9c9ddd43767" }
+libdd-trace-obfuscation = { git = "https://github.com/DataDog/libdatadog", rev = "fcdcb31d3e4871feb25df4f092b7224fdfa10c0d" }
+libdd-trace-utils = { git = "https://github.com/DataDog/libdatadog", rev = "fcdcb31d3e4871feb25df4f092b7224fdfa10c0d" }
 log = { version = "0.4", default-features = false }
 serde = { version = "1.0", default-features = false, features = ["derive"] }
 serde-aux = { version = "4.7", default-features = false }

--- a/crates/datadog-agent-config/Cargo.toml
+++ b/crates/datadog-agent-config/Cargo.toml
@@ -6,8 +6,8 @@ license.workspace = true
 
 [dependencies]
 figment = { version = "0.10", default-features = false, features = ["yaml", "env"] }
-libdd-trace-obfuscation = { git = "https://github.com/DataDog/libdatadog", rev = "48da0d82cb32b43d4cdece35b794c9bcbc275a03", default-features = false }
-libdd-trace-utils = { git = "https://github.com/DataDog/libdatadog", rev = "48da0d82cb32b43d4cdece35b794c9bcbc275a03", default-features = false }
+libdd-trace-obfuscation = { git = "https://github.com/DataDog/libdatadog", rev = "62e9d0148219f89fea3aab066235d9c9ddd43767" }
+libdd-trace-utils = { git = "https://github.com/DataDog/libdatadog", rev = "62e9d0148219f89fea3aab066235d9c9ddd43767" }
 log = { version = "0.4", default-features = false }
 serde = { version = "1.0", default-features = false, features = ["derive"] }
 serde-aux = { version = "4.7", default-features = false }

--- a/crates/datadog-agent-config/Cargo.toml
+++ b/crates/datadog-agent-config/Cargo.toml
@@ -6,8 +6,8 @@ license.workspace = true
 
 [dependencies]
 figment = { version = "0.10", default-features = false, features = ["yaml", "env"] }
-libdd-trace-obfuscation = { git = "https://github.com/DataDog/libdatadog", rev = "869d5709ec35410ab42c94a5904cdc8deec93bdf" }
-libdd-trace-utils = { git = "https://github.com/DataDog/libdatadog", rev = "869d5709ec35410ab42c94a5904cdc8deec93bdf" }
+libdd-trace-obfuscation = { git = "https://github.com/DataDog/libdatadog", rev = "a820699426f28cbabb3a74d87c7309d030b52e7c" }
+libdd-trace-utils = { git = "https://github.com/DataDog/libdatadog", rev = "a820699426f28cbabb3a74d87c7309d030b52e7c" }
 log = { version = "0.4", default-features = false }
 serde = { version = "1.0", default-features = false, features = ["derive"] }
 serde-aux = { version = "4.7", default-features = false }

--- a/crates/datadog-agent-config/Cargo.toml
+++ b/crates/datadog-agent-config/Cargo.toml
@@ -6,8 +6,8 @@ license.workspace = true
 
 [dependencies]
 figment = { version = "0.10", default-features = false, features = ["yaml", "env"] }
-libdd-trace-obfuscation = { git = "https://github.com/DataDog/libdatadog", rev = "fcdcb31d3e4871feb25df4f092b7224fdfa10c0d" }
-libdd-trace-utils = { git = "https://github.com/DataDog/libdatadog", rev = "fcdcb31d3e4871feb25df4f092b7224fdfa10c0d" }
+libdd-trace-obfuscation = { git = "https://github.com/DataDog/libdatadog", rev = "869d5709ec35410ab42c94a5904cdc8deec93bdf" }
+libdd-trace-utils = { git = "https://github.com/DataDog/libdatadog", rev = "869d5709ec35410ab42c94a5904cdc8deec93bdf" }
 log = { version = "0.4", default-features = false }
 serde = { version = "1.0", default-features = false, features = ["derive"] }
 serde-aux = { version = "4.7", default-features = false }

--- a/crates/datadog-agent-config/Cargo.toml
+++ b/crates/datadog-agent-config/Cargo.toml
@@ -6,8 +6,8 @@ license.workspace = true
 
 [dependencies]
 figment = { version = "0.10", default-features = false, features = ["yaml", "env"] }
-libdd-trace-obfuscation = { git = "https://github.com/DataDog/libdatadog", rev = "a820699426f28cbabb3a74d87c7309d030b52e7c" }
-libdd-trace-utils = { git = "https://github.com/DataDog/libdatadog", rev = "a820699426f28cbabb3a74d87c7309d030b52e7c" }
+libdd-trace-obfuscation = { git = "https://github.com/DataDog/libdatadog", rev = "a820699426f28cbabb3a74d87c7309d030b52e7c", default-features = false }
+libdd-trace-utils = { git = "https://github.com/DataDog/libdatadog", rev = "a820699426f28cbabb3a74d87c7309d030b52e7c", default-features = false }
 log = { version = "0.4", default-features = false }
 serde = { version = "1.0", default-features = false, features = ["derive"] }
 serde-aux = { version = "4.7", default-features = false }

--- a/crates/datadog-metrics-collector/Cargo.toml
+++ b/crates/datadog-metrics-collector/Cargo.toml
@@ -8,7 +8,7 @@ description = "Collector to read, compute, and submit enhanced metrics in Server
 [dependencies]
 dogstatsd = { path = "../dogstatsd", default-features = true }
 tracing = { version = "0.1", default-features = false }
-libdd-common = { git = "https://github.com/DataDog/libdatadog", rev = "869d5709ec35410ab42c94a5904cdc8deec93bdf", default-features = false }
+libdd-common = { git = "https://github.com/DataDog/libdatadog", rev = "a820699426f28cbabb3a74d87c7309d030b52e7c", default-features = false }
 
 [target.'cfg(windows)'.dependencies]
 windows-sys = { version = "0.61", features = ["Win32_System_JobObjects"], optional = true, default-features = false }

--- a/crates/datadog-metrics-collector/Cargo.toml
+++ b/crates/datadog-metrics-collector/Cargo.toml
@@ -8,7 +8,7 @@ description = "Collector to read, compute, and submit enhanced metrics in Server
 [dependencies]
 dogstatsd = { path = "../dogstatsd", default-features = true }
 tracing = { version = "0.1", default-features = false }
-libdd-common = { git = "https://github.com/DataDog/libdatadog", rev = "fcdcb31d3e4871feb25df4f092b7224fdfa10c0d", default-features = false }
+libdd-common = { git = "https://github.com/DataDog/libdatadog", rev = "869d5709ec35410ab42c94a5904cdc8deec93bdf", default-features = false }
 
 [target.'cfg(windows)'.dependencies]
 windows-sys = { version = "0.61", features = ["Win32_System_JobObjects"], optional = true, default-features = false }

--- a/crates/datadog-metrics-collector/Cargo.toml
+++ b/crates/datadog-metrics-collector/Cargo.toml
@@ -8,7 +8,7 @@ description = "Collector to read, compute, and submit enhanced metrics in Server
 [dependencies]
 dogstatsd = { path = "../dogstatsd", default-features = true }
 tracing = { version = "0.1", default-features = false }
-libdd-common = { git = "https://github.com/DataDog/libdatadog", rev = "48da0d82cb32b43d4cdece35b794c9bcbc275a03", default-features = false }
+libdd-common = { git = "https://github.com/DataDog/libdatadog", rev = "62e9d0148219f89fea3aab066235d9c9ddd43767", default-features = false }
 
 [target.'cfg(windows)'.dependencies]
 windows-sys = { version = "0.61", features = ["Win32_System_JobObjects"], optional = true, default-features = false }

--- a/crates/datadog-metrics-collector/Cargo.toml
+++ b/crates/datadog-metrics-collector/Cargo.toml
@@ -8,7 +8,7 @@ description = "Collector to read, compute, and submit enhanced metrics in Server
 [dependencies]
 dogstatsd = { path = "../dogstatsd", default-features = true }
 tracing = { version = "0.1", default-features = false }
-libdd-common = { git = "https://github.com/DataDog/libdatadog", rev = "62e9d0148219f89fea3aab066235d9c9ddd43767", default-features = false }
+libdd-common = { git = "https://github.com/DataDog/libdatadog", rev = "fcdcb31d3e4871feb25df4f092b7224fdfa10c0d", default-features = false }
 
 [target.'cfg(windows)'.dependencies]
 windows-sys = { version = "0.61", features = ["Win32_System_JobObjects"], optional = true, default-features = false }

--- a/crates/datadog-metrics-collector/src/azure_instance.rs
+++ b/crates/datadog-metrics-collector/src/azure_instance.rs
@@ -8,50 +8,10 @@
 
 use dogstatsd::aggregator::AggregatorHandle;
 use dogstatsd::metric::{Metric, MetricValue, SortedTags};
-use std::env;
+use libdd_common::azure_app_services;
 use tracing::{error, warn};
 
 const INSTANCE_METRIC: &str = "azure.functions.enhanced.instance";
-
-/// Resolves the instance ID from explicit values (used by tests).
-///
-/// Picks the env var that matches the Azure integration metric's `instance`
-/// tag for the current hosting plan with fallback logic
-/// if the preferred source is empty.
-fn resolve_instance_id_from(
-    website_sku: Option<&str>,
-    container_name: Option<&str>,
-    website_pod_name: Option<&str>,
-    computer_name: Option<&str>,
-) -> Option<String> {
-    fn non_empty(s: Option<&str>) -> Option<&str> {
-        s.filter(|v| !v.is_empty())
-    }
-
-    let sku_preferred = match website_sku {
-        Some("FlexConsumption") | Some("Dynamic") => {
-            non_empty(container_name).or(non_empty(website_pod_name))
-        }
-        Some(_) => non_empty(computer_name),
-        None => None,
-    };
-
-    sku_preferred
-        .or_else(|| non_empty(container_name))
-        .or_else(|| non_empty(website_pod_name))
-        .or_else(|| non_empty(computer_name))
-        .map(|s| s.to_lowercase())
-}
-
-/// Resolves the instance ID from environment variables.
-fn resolve_instance_id() -> Option<String> {
-    resolve_instance_id_from(
-        env::var("WEBSITE_SKU").ok().as_deref(),
-        env::var("CONTAINER_NAME").ok().as_deref(),
-        env::var("WEBSITE_POD_NAME").ok().as_deref(),
-        env::var("COMPUTERNAME").ok().as_deref(),
-    )
-}
 
 pub struct InstanceMetricsCollector {
     aggregator: AggregatorHandle,
@@ -61,8 +21,12 @@ pub struct InstanceMetricsCollector {
 impl InstanceMetricsCollector {
     /// Creates a new collector, returning `None` if no instance ID is found.
     pub fn new(aggregator: AggregatorHandle, tags: Option<SortedTags>) -> Option<Self> {
-        let instance_id = resolve_instance_id();
-        let Some(instance_id) = instance_id else {
+        let instance_name = azure_app_services::AAS_METADATA_FUNCTION
+            .as_ref()
+            .map(|m| m.get_instance_name().to_owned())
+            .filter(|n| n != azure_app_services::UNKNOWN_VALUE);
+
+        let Some(instance_id) = instance_name else {
             warn!("No instance ID found, instance metric will not be submitted");
             return None;
         };
@@ -93,84 +57,5 @@ impl InstanceMetricsCollector {
         if let Err(e) = self.aggregator.insert_batch(vec![metric]) {
             error!("Failed to insert instance metric: {}", e);
         }
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn test_flex_consumption_uses_container_name() {
-        let id = resolve_instance_id_from(
-            Some("FlexConsumption"),
-            Some("0--abc-DEF"),
-            Some("0--abc-DEF"),
-            None,
-        );
-        assert_eq!(id, Some("0--abc-def".to_string()));
-    }
-
-    #[test]
-    fn test_flex_consumption_falls_back_to_pod_name_if_container_missing() {
-        let id = resolve_instance_id_from(Some("FlexConsumption"), None, Some("pod-XYZ"), None);
-        assert_eq!(id, Some("pod-xyz".to_string()));
-    }
-
-    #[test]
-    fn test_consumption_uses_container_name() {
-        let id = resolve_instance_id_from(
-            Some("Dynamic"),
-            Some("ABCD1234-111122223333444455"),
-            None,
-            None,
-        );
-        assert_eq!(id, Some("abcd1234-111122223333444455".to_string()));
-    }
-
-    #[test]
-    fn test_elastic_premium_uses_computer_name() {
-        let id =
-            resolve_instance_id_from(Some("ElasticPremium"), None, None, Some("ep0fakewk0000A1"));
-        assert_eq!(id, Some("ep0fakewk0000a1".to_string()));
-    }
-
-    #[test]
-    fn test_dedicated_uses_computer_name() {
-        let id = resolve_instance_id_from(Some("PremiumV3"), None, None, Some("p3fakewk0000B2"));
-        assert_eq!(id, Some("p3fakewk0000b2".to_string()));
-    }
-
-    #[test]
-    fn test_empty_string_is_treated_as_missing() {
-        let id =
-            resolve_instance_id_from(Some("ElasticPremium"), Some(""), Some(""), Some("worker-1"));
-        assert_eq!(id, Some("worker-1".to_string()));
-    }
-
-    #[test]
-    fn test_unknown_sku_falls_back_to_search_order() {
-        let id = resolve_instance_id_from(Some("SomeNewSku"), Some("container-1"), None, None);
-        assert_eq!(id, Some("container-1".to_string()));
-    }
-
-    #[test]
-    fn test_missing_sku_falls_back_to_search_order() {
-        let id = resolve_instance_id_from(None, Some("container-1"), None, Some("worker-1"));
-        assert_eq!(id, Some("container-1".to_string()));
-    }
-
-    #[test]
-    fn test_no_env_vars_returns_none() {
-        let id = resolve_instance_id_from(None, None, None, None);
-        assert_eq!(id, None);
-    }
-
-    // On Windows Consumption we've observed CONTAINER_NAME and WEBSITE_POD_NAME
-    // unset but COMPUTERNAME set
-    #[test]
-    fn test_windows_consumption_falls_through_to_computer_name() {
-        let id = resolve_instance_id_from(Some("Dynamic"), None, None, Some("10-20-30-40"));
-        assert_eq!(id, Some("10-20-30-40".to_string()));
     }
 }

--- a/crates/datadog-metrics-collector/src/azure_instance.rs
+++ b/crates/datadog-metrics-collector/src/azure_instance.rs
@@ -23,7 +23,7 @@ impl InstanceMetricsCollector {
     pub fn new(aggregator: AggregatorHandle, tags: Option<SortedTags>) -> Option<Self> {
         let instance_name = azure_app_services::AAS_METADATA_FUNCTION
             .as_ref()
-            .map(|m| m.get_instance_name().to_owned())
+            .map(|m| m.get_instance_name().to_lowercase())
             .filter(|n| n != azure_app_services::UNKNOWN_VALUE);
 
         let Some(instance_id) = instance_name else {

--- a/crates/datadog-metrics-collector/src/azure_tags.rs
+++ b/crates/datadog-metrics-collector/src/azure_tags.rs
@@ -10,9 +10,6 @@ use libdd_common::{azure_app_services, tag::Tag};
 use std::env;
 use tracing::warn;
 
-/// `libdd_common::azure_app_services` returns this value when the corresponding Azure metadata isn't populated.
-const AAS_UNKNOWN_VALUE: &str = "unknown";
-
 /// Builds the common tags for all enhanced metrics.
 ///
 /// Sources:
@@ -30,15 +27,15 @@ pub fn build_enhanced_metrics_tags() -> Option<SortedTags> {
             ("subscription_id", aas_metadata.get_subscription_id()),
             ("name", aas_metadata.get_site_name()),
         ] {
-            if value != AAS_UNKNOWN_VALUE {
+            if value != azure_app_services::UNKNOWN_VALUE {
                 pairs.push((name, value.to_string()));
             }
         }
     }
 
     for (tag_name, env_var) in [
-        ("region", "REGION_NAME"),
-        ("plan_tier", "WEBSITE_SKU"),
+        ("region", azure_app_services::REGION_NAME),
+        ("plan_tier", azure_app_services::WEBSITE_SKU),
         ("service", "DD_SERVICE"),
         ("env", "DD_ENV"),
         ("version", "DD_VERSION"),

--- a/crates/datadog-serverless-compat/Cargo.toml
+++ b/crates/datadog-serverless-compat/Cargo.toml
@@ -14,7 +14,7 @@ windows-enhanced-metrics = ["datadog-metrics-collector/windows-enhanced-metrics"
 datadog-logs-agent = { path = "../datadog-logs-agent" }
 datadog-metrics-collector = { path = "../datadog-metrics-collector" }
 datadog-trace-agent = { path = "../datadog-trace-agent" }
-libdd-trace-utils = { git = "https://github.com/DataDog/libdatadog", rev = "fcdcb31d3e4871feb25df4f092b7224fdfa10c0d" }
+libdd-trace-utils = { git = "https://github.com/DataDog/libdatadog", rev = "869d5709ec35410ab42c94a5904cdc8deec93bdf" }
 datadog-fips = { path = "../datadog-fips", default-features = false }
 dogstatsd = { path = "../dogstatsd", default-features = true }
 reqwest = { version = "0.12.4", default-features = false }

--- a/crates/datadog-serverless-compat/Cargo.toml
+++ b/crates/datadog-serverless-compat/Cargo.toml
@@ -14,7 +14,7 @@ windows-enhanced-metrics = ["datadog-metrics-collector/windows-enhanced-metrics"
 datadog-logs-agent = { path = "../datadog-logs-agent" }
 datadog-metrics-collector = { path = "../datadog-metrics-collector" }
 datadog-trace-agent = { path = "../datadog-trace-agent" }
-libdd-trace-utils = { git = "https://github.com/DataDog/libdatadog", rev = "62e9d0148219f89fea3aab066235d9c9ddd43767" }
+libdd-trace-utils = { git = "https://github.com/DataDog/libdatadog", rev = "fcdcb31d3e4871feb25df4f092b7224fdfa10c0d" }
 datadog-fips = { path = "../datadog-fips", default-features = false }
 dogstatsd = { path = "../dogstatsd", default-features = true }
 reqwest = { version = "0.12.4", default-features = false }

--- a/crates/datadog-serverless-compat/Cargo.toml
+++ b/crates/datadog-serverless-compat/Cargo.toml
@@ -14,7 +14,7 @@ windows-enhanced-metrics = ["datadog-metrics-collector/windows-enhanced-metrics"
 datadog-logs-agent = { path = "../datadog-logs-agent" }
 datadog-metrics-collector = { path = "../datadog-metrics-collector" }
 datadog-trace-agent = { path = "../datadog-trace-agent" }
-libdd-trace-utils = { git = "https://github.com/DataDog/libdatadog", rev = "869d5709ec35410ab42c94a5904cdc8deec93bdf" }
+libdd-trace-utils = { git = "https://github.com/DataDog/libdatadog", rev = "a820699426f28cbabb3a74d87c7309d030b52e7c" }
 datadog-fips = { path = "../datadog-fips", default-features = false }
 dogstatsd = { path = "../dogstatsd", default-features = true }
 reqwest = { version = "0.12.4", default-features = false }

--- a/crates/datadog-serverless-compat/Cargo.toml
+++ b/crates/datadog-serverless-compat/Cargo.toml
@@ -14,7 +14,7 @@ windows-enhanced-metrics = ["datadog-metrics-collector/windows-enhanced-metrics"
 datadog-logs-agent = { path = "../datadog-logs-agent" }
 datadog-metrics-collector = { path = "../datadog-metrics-collector" }
 datadog-trace-agent = { path = "../datadog-trace-agent" }
-libdd-trace-utils = { git = "https://github.com/DataDog/libdatadog", rev = "48da0d82cb32b43d4cdece35b794c9bcbc275a03" }
+libdd-trace-utils = { git = "https://github.com/DataDog/libdatadog", rev = "62e9d0148219f89fea3aab066235d9c9ddd43767" }
 datadog-fips = { path = "../datadog-fips", default-features = false }
 dogstatsd = { path = "../dogstatsd", default-features = true }
 reqwest = { version = "0.12.4", default-features = false }

--- a/crates/datadog-trace-agent/Cargo.toml
+++ b/crates/datadog-trace-agent/Cargo.toml
@@ -25,16 +25,16 @@ tracing = { version = "0.1", default-features = false }
 serde = { version = "1.0.145", features = ["derive"] }
 serde_json = "1.0"
 thiserror = { version = "1.0.58", default-features = false }
-libdd-capabilities = { git = "https://github.com/DataDog/libdatadog", rev = "48da0d82cb32b43d4cdece35b794c9bcbc275a03" }
-libdd-capabilities-impl = { git = "https://github.com/DataDog/libdatadog", rev = "48da0d82cb32b43d4cdece35b794c9bcbc275a03" }
-libdd-common = { git = "https://github.com/DataDog/libdatadog", rev = "48da0d82cb32b43d4cdece35b794c9bcbc275a03" }
-libdd-library-config = { git = "https://github.com/DataDog/libdatadog", rev = "48da0d82cb32b43d4cdece35b794c9bcbc275a03" }
-libdd-trace-protobuf = { git = "https://github.com/DataDog/libdatadog", rev = "48da0d82cb32b43d4cdece35b794c9bcbc275a03" }
-libdd-trace-stats = { git = "https://github.com/DataDog/libdatadog", rev = "48da0d82cb32b43d4cdece35b794c9bcbc275a03" }
-libdd-trace-utils = { git = "https://github.com/DataDog/libdatadog", rev = "48da0d82cb32b43d4cdece35b794c9bcbc275a03", features = [
+libdd-capabilities = { git = "https://github.com/DataDog/libdatadog", rev = "62e9d0148219f89fea3aab066235d9c9ddd43767" }
+libdd-capabilities-impl = { git = "https://github.com/DataDog/libdatadog", rev = "62e9d0148219f89fea3aab066235d9c9ddd43767" }
+libdd-common = { git = "https://github.com/DataDog/libdatadog", rev = "62e9d0148219f89fea3aab066235d9c9ddd43767" }
+libdd-library-config = { git = "https://github.com/DataDog/libdatadog", rev = "62e9d0148219f89fea3aab066235d9c9ddd43767" }
+libdd-trace-protobuf = { git = "https://github.com/DataDog/libdatadog", rev = "62e9d0148219f89fea3aab066235d9c9ddd43767" }
+libdd-trace-stats = { git = "https://github.com/DataDog/libdatadog", rev = "62e9d0148219f89fea3aab066235d9c9ddd43767" }
+libdd-trace-utils = { git = "https://github.com/DataDog/libdatadog", rev = "62e9d0148219f89fea3aab066235d9c9ddd43767", features = [
     "mini_agent",
 ] }
-libdd-trace-obfuscation = { git = "https://github.com/DataDog/libdatadog", rev = "48da0d82cb32b43d4cdece35b794c9bcbc275a03" }
+libdd-trace-obfuscation = { git = "https://github.com/DataDog/libdatadog", rev = "62e9d0148219f89fea3aab066235d9c9ddd43767" }
 datadog-fips = { path = "../datadog-fips" }
 reqwest = { version = "0.12.23", features = [
     "json",
@@ -49,6 +49,6 @@ serial_test = "2.0.0"
 duplicate = "2.0.1"
 temp-env = "0.3.6"
 tempfile = "3.3.0"
-libdd-trace-utils = { git = "https://github.com/DataDog/libdatadog", rev = "48da0d82cb32b43d4cdece35b794c9bcbc275a03", features = [
+libdd-trace-utils = { git = "https://github.com/DataDog/libdatadog", rev = "62e9d0148219f89fea3aab066235d9c9ddd43767", features = [
     "test-utils",
 ] }

--- a/crates/datadog-trace-agent/Cargo.toml
+++ b/crates/datadog-trace-agent/Cargo.toml
@@ -25,16 +25,16 @@ tracing = { version = "0.1", default-features = false }
 serde = { version = "1.0.145", features = ["derive"] }
 serde_json = "1.0"
 thiserror = { version = "1.0.58", default-features = false }
-libdd-capabilities = { git = "https://github.com/DataDog/libdatadog", rev = "869d5709ec35410ab42c94a5904cdc8deec93bdf" }
-libdd-capabilities-impl = { git = "https://github.com/DataDog/libdatadog", rev = "869d5709ec35410ab42c94a5904cdc8deec93bdf" }
-libdd-common = { git = "https://github.com/DataDog/libdatadog", rev = "869d5709ec35410ab42c94a5904cdc8deec93bdf" }
-libdd-library-config = { git = "https://github.com/DataDog/libdatadog", rev = "869d5709ec35410ab42c94a5904cdc8deec93bdf" }
-libdd-trace-protobuf = { git = "https://github.com/DataDog/libdatadog", rev = "869d5709ec35410ab42c94a5904cdc8deec93bdf" }
-libdd-trace-stats = { git = "https://github.com/DataDog/libdatadog", rev = "869d5709ec35410ab42c94a5904cdc8deec93bdf" }
-libdd-trace-utils = { git = "https://github.com/DataDog/libdatadog", rev = "869d5709ec35410ab42c94a5904cdc8deec93bdf", features = [
+libdd-capabilities = { git = "https://github.com/DataDog/libdatadog", rev = "a820699426f28cbabb3a74d87c7309d030b52e7c" }
+libdd-capabilities-impl = { git = "https://github.com/DataDog/libdatadog", rev = "a820699426f28cbabb3a74d87c7309d030b52e7c" }
+libdd-common = { git = "https://github.com/DataDog/libdatadog", rev = "a820699426f28cbabb3a74d87c7309d030b52e7c" }
+libdd-library-config = { git = "https://github.com/DataDog/libdatadog", rev = "a820699426f28cbabb3a74d87c7309d030b52e7c" }
+libdd-trace-protobuf = { git = "https://github.com/DataDog/libdatadog", rev = "a820699426f28cbabb3a74d87c7309d030b52e7c" }
+libdd-trace-stats = { git = "https://github.com/DataDog/libdatadog", rev = "a820699426f28cbabb3a74d87c7309d030b52e7c" }
+libdd-trace-utils = { git = "https://github.com/DataDog/libdatadog", rev = "a820699426f28cbabb3a74d87c7309d030b52e7c", features = [
     "mini_agent",
 ] }
-libdd-trace-obfuscation = { git = "https://github.com/DataDog/libdatadog", rev = "869d5709ec35410ab42c94a5904cdc8deec93bdf" }
+libdd-trace-obfuscation = { git = "https://github.com/DataDog/libdatadog", rev = "a820699426f28cbabb3a74d87c7309d030b52e7c" }
 datadog-fips = { path = "../datadog-fips" }
 reqwest = { version = "0.12.23", features = [
     "json",
@@ -49,6 +49,6 @@ serial_test = "2.0.0"
 duplicate = "2.0.1"
 temp-env = "0.3.6"
 tempfile = "3.3.0"
-libdd-trace-utils = { git = "https://github.com/DataDog/libdatadog", rev = "869d5709ec35410ab42c94a5904cdc8deec93bdf", features = [
+libdd-trace-utils = { git = "https://github.com/DataDog/libdatadog", rev = "a820699426f28cbabb3a74d87c7309d030b52e7c", features = [
     "test-utils",
 ] }

--- a/crates/datadog-trace-agent/Cargo.toml
+++ b/crates/datadog-trace-agent/Cargo.toml
@@ -25,16 +25,16 @@ tracing = { version = "0.1", default-features = false }
 serde = { version = "1.0.145", features = ["derive"] }
 serde_json = "1.0"
 thiserror = { version = "1.0.58", default-features = false }
-libdd-capabilities = { git = "https://github.com/DataDog/libdatadog", rev = "62e9d0148219f89fea3aab066235d9c9ddd43767" }
-libdd-capabilities-impl = { git = "https://github.com/DataDog/libdatadog", rev = "62e9d0148219f89fea3aab066235d9c9ddd43767" }
-libdd-common = { git = "https://github.com/DataDog/libdatadog", rev = "62e9d0148219f89fea3aab066235d9c9ddd43767" }
-libdd-library-config = { git = "https://github.com/DataDog/libdatadog", rev = "62e9d0148219f89fea3aab066235d9c9ddd43767" }
-libdd-trace-protobuf = { git = "https://github.com/DataDog/libdatadog", rev = "62e9d0148219f89fea3aab066235d9c9ddd43767" }
-libdd-trace-stats = { git = "https://github.com/DataDog/libdatadog", rev = "62e9d0148219f89fea3aab066235d9c9ddd43767" }
-libdd-trace-utils = { git = "https://github.com/DataDog/libdatadog", rev = "62e9d0148219f89fea3aab066235d9c9ddd43767", features = [
+libdd-capabilities = { git = "https://github.com/DataDog/libdatadog", rev = "fcdcb31d3e4871feb25df4f092b7224fdfa10c0d" }
+libdd-capabilities-impl = { git = "https://github.com/DataDog/libdatadog", rev = "fcdcb31d3e4871feb25df4f092b7224fdfa10c0d" }
+libdd-common = { git = "https://github.com/DataDog/libdatadog", rev = "fcdcb31d3e4871feb25df4f092b7224fdfa10c0d" }
+libdd-library-config = { git = "https://github.com/DataDog/libdatadog", rev = "fcdcb31d3e4871feb25df4f092b7224fdfa10c0d" }
+libdd-trace-protobuf = { git = "https://github.com/DataDog/libdatadog", rev = "fcdcb31d3e4871feb25df4f092b7224fdfa10c0d" }
+libdd-trace-stats = { git = "https://github.com/DataDog/libdatadog", rev = "fcdcb31d3e4871feb25df4f092b7224fdfa10c0d" }
+libdd-trace-utils = { git = "https://github.com/DataDog/libdatadog", rev = "fcdcb31d3e4871feb25df4f092b7224fdfa10c0d", features = [
     "mini_agent",
 ] }
-libdd-trace-obfuscation = { git = "https://github.com/DataDog/libdatadog", rev = "62e9d0148219f89fea3aab066235d9c9ddd43767" }
+libdd-trace-obfuscation = { git = "https://github.com/DataDog/libdatadog", rev = "fcdcb31d3e4871feb25df4f092b7224fdfa10c0d" }
 datadog-fips = { path = "../datadog-fips" }
 reqwest = { version = "0.12.23", features = [
     "json",
@@ -49,6 +49,6 @@ serial_test = "2.0.0"
 duplicate = "2.0.1"
 temp-env = "0.3.6"
 tempfile = "3.3.0"
-libdd-trace-utils = { git = "https://github.com/DataDog/libdatadog", rev = "62e9d0148219f89fea3aab066235d9c9ddd43767", features = [
+libdd-trace-utils = { git = "https://github.com/DataDog/libdatadog", rev = "fcdcb31d3e4871feb25df4f092b7224fdfa10c0d", features = [
     "test-utils",
 ] }

--- a/crates/datadog-trace-agent/Cargo.toml
+++ b/crates/datadog-trace-agent/Cargo.toml
@@ -25,16 +25,16 @@ tracing = { version = "0.1", default-features = false }
 serde = { version = "1.0.145", features = ["derive"] }
 serde_json = "1.0"
 thiserror = { version = "1.0.58", default-features = false }
-libdd-capabilities = { git = "https://github.com/DataDog/libdatadog", rev = "fcdcb31d3e4871feb25df4f092b7224fdfa10c0d" }
-libdd-capabilities-impl = { git = "https://github.com/DataDog/libdatadog", rev = "fcdcb31d3e4871feb25df4f092b7224fdfa10c0d" }
-libdd-common = { git = "https://github.com/DataDog/libdatadog", rev = "fcdcb31d3e4871feb25df4f092b7224fdfa10c0d" }
-libdd-library-config = { git = "https://github.com/DataDog/libdatadog", rev = "fcdcb31d3e4871feb25df4f092b7224fdfa10c0d" }
-libdd-trace-protobuf = { git = "https://github.com/DataDog/libdatadog", rev = "fcdcb31d3e4871feb25df4f092b7224fdfa10c0d" }
-libdd-trace-stats = { git = "https://github.com/DataDog/libdatadog", rev = "fcdcb31d3e4871feb25df4f092b7224fdfa10c0d" }
-libdd-trace-utils = { git = "https://github.com/DataDog/libdatadog", rev = "fcdcb31d3e4871feb25df4f092b7224fdfa10c0d", features = [
+libdd-capabilities = { git = "https://github.com/DataDog/libdatadog", rev = "869d5709ec35410ab42c94a5904cdc8deec93bdf" }
+libdd-capabilities-impl = { git = "https://github.com/DataDog/libdatadog", rev = "869d5709ec35410ab42c94a5904cdc8deec93bdf" }
+libdd-common = { git = "https://github.com/DataDog/libdatadog", rev = "869d5709ec35410ab42c94a5904cdc8deec93bdf" }
+libdd-library-config = { git = "https://github.com/DataDog/libdatadog", rev = "869d5709ec35410ab42c94a5904cdc8deec93bdf" }
+libdd-trace-protobuf = { git = "https://github.com/DataDog/libdatadog", rev = "869d5709ec35410ab42c94a5904cdc8deec93bdf" }
+libdd-trace-stats = { git = "https://github.com/DataDog/libdatadog", rev = "869d5709ec35410ab42c94a5904cdc8deec93bdf" }
+libdd-trace-utils = { git = "https://github.com/DataDog/libdatadog", rev = "869d5709ec35410ab42c94a5904cdc8deec93bdf", features = [
     "mini_agent",
 ] }
-libdd-trace-obfuscation = { git = "https://github.com/DataDog/libdatadog", rev = "fcdcb31d3e4871feb25df4f092b7224fdfa10c0d" }
+libdd-trace-obfuscation = { git = "https://github.com/DataDog/libdatadog", rev = "869d5709ec35410ab42c94a5904cdc8deec93bdf" }
 datadog-fips = { path = "../datadog-fips" }
 reqwest = { version = "0.12.23", features = [
     "json",
@@ -49,6 +49,6 @@ serial_test = "2.0.0"
 duplicate = "2.0.1"
 temp-env = "0.3.6"
 tempfile = "3.3.0"
-libdd-trace-utils = { git = "https://github.com/DataDog/libdatadog", rev = "fcdcb31d3e4871feb25df4f092b7224fdfa10c0d", features = [
+libdd-trace-utils = { git = "https://github.com/DataDog/libdatadog", rev = "869d5709ec35410ab42c94a5904cdc8deec93bdf", features = [
     "test-utils",
 ] }

--- a/crates/datadog-trace-agent/src/env_verifier.rs
+++ b/crates/datadog-trace-agent/src/env_verifier.rs
@@ -4,6 +4,7 @@
 use async_trait::async_trait;
 use http_body_util::BodyExt;
 use hyper::{Method, Request};
+use libdd_common::azure_app_services;
 use libdd_common::http_common;
 use serde::{Deserialize, Serialize};
 use std::env;
@@ -24,7 +25,6 @@ const AZURE_FUNCTION_JSON_NAME: &str = "function.json";
 
 // Azure environment variables for Flex consumption plan detection
 const DD_AZURE_RESOURCE_GROUP: &str = "DD_AZURE_RESOURCE_GROUP";
-const WEBSITE_SKU: &str = "WEBSITE_SKU";
 
 #[derive(Default, Debug, Deserialize, Serialize, Eq, PartialEq)]
 pub struct GCPMetadata {
@@ -253,7 +253,7 @@ async fn get_gcp_metadata_from_body(body: http_common::Body) -> anyhow::Result<G
 /// Checks if we're running in Azure Flex Consumption plan without DD_AZURE_RESOURCE_GROUP set
 /// This would cause billing issues, so we should shut down the trace agent
 fn is_azure_flex_without_resource_group() -> bool {
-    env::var(WEBSITE_SKU)
+    env::var(azure_app_services::WEBSITE_SKU)
         .map(|sku| sku == "FlexConsumption")
         .unwrap_or(false)
         && env::var(DD_AZURE_RESOURCE_GROUP).is_err()
@@ -370,10 +370,11 @@ mod tests {
     use crate::env_verifier::{
         AZURE_FUNCTION_JSON_NAME, AZURE_HOST_JSON_NAME, AzureVerificationClient,
         AzureVerificationClientWrapper, DD_AZURE_RESOURCE_GROUP, GCPInstance, GCPMetadata,
-        GCPProject, GoogleMetadataClient, WEBSITE_SKU, ensure_azure_function_environment,
+        GCPProject, GoogleMetadataClient, ensure_azure_function_environment,
         ensure_gcp_function_environment, get_region_from_gcp_region_string,
         is_azure_flex_without_resource_group,
     };
+    use libdd_common::azure_app_services;
 
     use super::{EnvVerifier, ServerlessEnvVerifier};
 
@@ -651,7 +652,7 @@ mod tests {
         temp_env::with_vars(
             [
                 (DD_AZURE_RESOURCE_GROUP, None::<&str>),
-                (WEBSITE_SKU, Some("FlexConsumption")),
+                (azure_app_services::WEBSITE_SKU, Some("FlexConsumption")),
             ],
             || assert!(is_azure_flex_without_resource_group()),
         );
@@ -663,7 +664,7 @@ mod tests {
         temp_env::with_vars(
             [
                 (DD_AZURE_RESOURCE_GROUP, Some("test-resource-group")),
-                (WEBSITE_SKU, Some("FlexConsumption")),
+                (azure_app_services::WEBSITE_SKU, Some("FlexConsumption")),
             ],
             || assert!(!is_azure_flex_without_resource_group()),
         );
@@ -675,7 +676,7 @@ mod tests {
         temp_env::with_vars(
             [
                 (DD_AZURE_RESOURCE_GROUP, None::<&str>),
-                (WEBSITE_SKU, Some("ElasticPremium")),
+                (azure_app_services::WEBSITE_SKU, Some("ElasticPremium")),
             ],
             || assert!(!is_azure_flex_without_resource_group()),
         );

--- a/crates/datadog-trace-agent/src/env_verifier.rs
+++ b/crates/datadog-trace-agent/src/env_verifier.rs
@@ -22,8 +22,6 @@ const AZURE_LINUX_FUNCTION_ROOT_PATH_STR: &str = "/home/site/wwwroot";
 const AZURE_WINDOWS_FUNCTION_ROOT_PATH_STR: &str = "C:\\home\\site\\wwwroot";
 const AZURE_HOST_JSON_NAME: &str = "host.json";
 const AZURE_FUNCTION_JSON_NAME: &str = "function.json";
-
-// Azure environment variables for Flex consumption plan detection
 const DD_AZURE_RESOURCE_GROUP: &str = "DD_AZURE_RESOURCE_GROUP";
 
 #[derive(Default, Debug, Deserialize, Serialize, Eq, PartialEq)]


### PR DESCRIPTION
### What does this PR do?

With https://github.com/DataDog/libdatadog/pull/2077 we moved the instance name resolution logic and any consts gathered from environment variables to libdd-common. This PR updates the libdatadog rev and uses the libdd-common logic and public consts.

<!-- A brief description of the change being made with this pull request. -->

### Motivation

https://datadoghq.atlassian.net/browse/SVLS-9015
<!-- Why is this change needed? Link any related Jira cards here. -->

### Additional Notes

<!-- Any other relevant context that would be helpful. -->

### Describe how to test/QA your changes

<!-- How was the change validated? Are there automated tests to prevent regressions? -->
Deployed an Azure Function and confirmed that the `instance` tag in the instance enhanced metric is the same. See https://github.com/DataDog/libdatadog/pull/2077 for testing the `instance_name` span attribute with screenshots.