### PR TITLE
chore(deps): bump libdatadog to 48da0d8

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -448,7 +448,7 @@ dependencies = [
  "dogstatsd",
  "figment",
  "libdd-trace-obfuscation",
- "libdd-trace-utils 3.0.1",
+ "libdd-trace-utils 6.0.1",
  "log",
  "serde",
  "serde-aux",
@@ -492,7 +492,7 @@ name = "datadog-metrics-collector"
 version = "0.1.0"
 dependencies = [
  "dogstatsd",
- "libdd-common 4.0.0",
+ "libdd-common 4.2.0",
  "tokio",
  "tracing",
  "windows-sys 0.61.2",
@@ -514,7 +514,7 @@ dependencies = [
  "libdd-common 2.0.1",
  "libdd-data-pipeline",
  "libdd-telemetry",
- "libdd-tinybytes 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libdd-tinybytes 1.1.0",
  "libdd-trace-utils 2.0.2",
  "lru",
  "opentelemetry",
@@ -554,7 +554,7 @@ dependencies = [
  "datadog-metrics-collector",
  "datadog-trace-agent",
  "dogstatsd",
- "libdd-trace-utils 3.0.1",
+ "libdd-trace-utils 6.0.1",
  "reqwest",
  "serde_json",
  "tokio",
@@ -580,12 +580,12 @@ dependencies = [
  "hyper-util",
  "libdd-capabilities",
  "libdd-capabilities-impl",
- "libdd-common 4.0.0",
+ "libdd-common 4.2.0",
  "libdd-library-config",
  "libdd-trace-obfuscation",
- "libdd-trace-protobuf 3.0.1",
- "libdd-trace-stats 2.0.0",
- "libdd-trace-utils 3.0.1",
+ "libdd-trace-protobuf 3.0.2",
+ "libdd-trace-stats 4.0.0",
+ "libdd-trace-utils 6.0.1",
  "reqwest",
  "rmp-serde",
  "serde",
@@ -1446,8 +1446,8 @@ checksum = "b5b646652bf6661599e1da8901b3b9522896f01e736bad5f723fe7a3a27f899d"
 
 [[package]]
 name = "libdd-capabilities"
-version = "1.0.0"
-source = "git+https://github.com/DataDog/libdatadog?rev=0a3304c6aaf84738786b670d706a01edc22dab81#0a3304c6aaf84738786b670d706a01edc22dab81"
+version = "2.0.0"
+source = "git+https://github.com/DataDog/libdatadog?rev=48da0d82cb32b43d4cdece35b794c9bcbc275a03#48da0d82cb32b43d4cdece35b794c9bcbc275a03"
 dependencies = [
  "anyhow",
  "bytes",
@@ -1457,14 +1457,14 @@ dependencies = [
 
 [[package]]
 name = "libdd-capabilities-impl"
-version = "1.0.0"
-source = "git+https://github.com/DataDog/libdatadog?rev=0a3304c6aaf84738786b670d706a01edc22dab81#0a3304c6aaf84738786b670d706a01edc22dab81"
+version = "2.0.0"
+source = "git+https://github.com/DataDog/libdatadog?rev=48da0d82cb32b43d4cdece35b794c9bcbc275a03#48da0d82cb32b43d4cdece35b794c9bcbc275a03"
 dependencies = [
  "bytes",
  "http",
  "http-body-util",
  "libdd-capabilities",
- "libdd-common 4.0.0",
+ "libdd-common 4.2.0",
  "tokio",
 ]
 
@@ -1501,8 +1501,8 @@ dependencies = [
 
 [[package]]
 name = "libdd-common"
-version = "4.0.0"
-source = "git+https://github.com/DataDog/libdatadog?rev=0a3304c6aaf84738786b670d706a01edc22dab81#0a3304c6aaf84738786b670d706a01edc22dab81"
+version = "4.2.0"
+source = "git+https://github.com/DataDog/libdatadog?rev=48da0d82cb32b43d4cdece35b794c9bcbc275a03#48da0d82cb32b43d4cdece35b794c9bcbc275a03"
 dependencies = [
  "anyhow",
  "bytes",
@@ -1549,7 +1549,7 @@ dependencies = [
  "libdd-ddsketch 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "libdd-dogstatsd-client",
  "libdd-telemetry",
- "libdd-tinybytes 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libdd-tinybytes 1.1.0",
  "libdd-trace-protobuf 2.0.0",
  "libdd-trace-stats 1.0.3",
  "libdd-trace-utils 2.0.2",
@@ -1575,7 +1575,7 @@ dependencies = [
 [[package]]
 name = "libdd-ddsketch"
 version = "1.0.1"
-source = "git+https://github.com/DataDog/libdatadog?rev=0a3304c6aaf84738786b670d706a01edc22dab81#0a3304c6aaf84738786b670d706a01edc22dab81"
+source = "git+https://github.com/DataDog/libdatadog?rev=48da0d82cb32b43d4cdece35b794c9bcbc275a03#48da0d82cb32b43d4cdece35b794c9bcbc275a03"
 dependencies = [
  "prost 0.14.3",
 ]
@@ -1596,12 +1596,12 @@ dependencies = [
 
 [[package]]
 name = "libdd-library-config"
-version = "1.1.0"
-source = "git+https://github.com/DataDog/libdatadog?rev=0a3304c6aaf84738786b670d706a01edc22dab81#0a3304c6aaf84738786b670d706a01edc22dab81"
+version = "2.0.0"
+source = "git+https://github.com/DataDog/libdatadog?rev=48da0d82cb32b43d4cdece35b794c9bcbc275a03#48da0d82cb32b43d4cdece35b794c9bcbc275a03"
 dependencies = [
  "anyhow",
  "libc",
- "libdd-trace-protobuf 3.0.1",
+ "libdd-trace-protobuf 3.0.2",
  "memfd",
  "prost 0.14.3",
  "rand 0.8.6",
@@ -1613,15 +1613,15 @@ dependencies = [
 
 [[package]]
 name = "libdd-shared-runtime"
-version = "0.1.0"
-source = "git+https://github.com/DataDog/libdatadog?rev=0a3304c6aaf84738786b670d706a01edc22dab81#0a3304c6aaf84738786b670d706a01edc22dab81"
+version = "1.0.0"
+source = "git+https://github.com/DataDog/libdatadog?rev=48da0d82cb32b43d4cdece35b794c9bcbc275a03#48da0d82cb32b43d4cdece35b794c9bcbc275a03"
 dependencies = [
  "async-trait",
  "futures",
  "futures-util",
  "libdd-capabilities",
  "libdd-capabilities-impl",
- "libdd-common 4.0.0",
+ "libdd-common 4.2.0",
  "tokio",
  "tokio-util",
  "tracing",
@@ -1664,8 +1664,8 @@ dependencies = [
 
 [[package]]
 name = "libdd-tinybytes"
-version = "1.1.0"
-source = "git+https://github.com/DataDog/libdatadog?rev=0a3304c6aaf84738786b670d706a01edc22dab81#0a3304c6aaf84738786b670d706a01edc22dab81"
+version = "1.1.1"
+source = "git+https://github.com/DataDog/libdatadog?rev=48da0d82cb32b43d4cdece35b794c9bcbc275a03#48da0d82cb32b43d4cdece35b794c9bcbc275a03"
 dependencies = [
  "serde",
 ]
@@ -1683,22 +1683,22 @@ dependencies = [
 [[package]]
 name = "libdd-trace-normalization"
 version = "2.0.0"
-source = "git+https://github.com/DataDog/libdatadog?rev=0a3304c6aaf84738786b670d706a01edc22dab81#0a3304c6aaf84738786b670d706a01edc22dab81"
+source = "git+https://github.com/DataDog/libdatadog?rev=48da0d82cb32b43d4cdece35b794c9bcbc275a03#48da0d82cb32b43d4cdece35b794c9bcbc275a03"
 dependencies = [
  "anyhow",
- "libdd-trace-protobuf 3.0.1",
+ "libdd-trace-protobuf 3.0.2",
 ]
 
 [[package]]
 name = "libdd-trace-obfuscation"
-version = "2.0.0"
-source = "git+https://github.com/DataDog/libdatadog?rev=0a3304c6aaf84738786b670d706a01edc22dab81#0a3304c6aaf84738786b670d706a01edc22dab81"
+version = "3.1.0"
+source = "git+https://github.com/DataDog/libdatadog?rev=48da0d82cb32b43d4cdece35b794c9bcbc275a03#48da0d82cb32b43d4cdece35b794c9bcbc275a03"
 dependencies = [
  "anyhow",
  "fluent-uri",
- "libdd-common 4.0.0",
- "libdd-trace-protobuf 3.0.1",
- "libdd-trace-utils 3.0.1",
+ "libdd-common 4.2.0",
+ "libdd-trace-protobuf 3.0.2",
+ "libdd-trace-utils 6.0.1",
  "log",
  "percent-encoding",
  "serde",
@@ -1718,8 +1718,8 @@ dependencies = [
 
 [[package]]
 name = "libdd-trace-protobuf"
-version = "3.0.1"
-source = "git+https://github.com/DataDog/libdatadog?rev=0a3304c6aaf84738786b670d706a01edc22dab81#0a3304c6aaf84738786b670d706a01edc22dab81"
+version = "3.0.2"
+source = "git+https://github.com/DataDog/libdatadog?rev=48da0d82cb32b43d4cdece35b794c9bcbc275a03#48da0d82cb32b43d4cdece35b794c9bcbc275a03"
 dependencies = [
  "prost 0.14.3",
  "serde",
@@ -1740,8 +1740,8 @@ dependencies = [
 
 [[package]]
 name = "libdd-trace-stats"
-version = "2.0.0"
-source = "git+https://github.com/DataDog/libdatadog?rev=0a3304c6aaf84738786b670d706a01edc22dab81#0a3304c6aaf84738786b670d706a01edc22dab81"
+version = "4.0.0"
+source = "git+https://github.com/DataDog/libdatadog?rev=48da0d82cb32b43d4cdece35b794c9bcbc275a03#48da0d82cb32b43d4cdece35b794c9bcbc275a03"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -1750,12 +1750,12 @@ dependencies = [
  "http",
  "libdd-capabilities",
  "libdd-capabilities-impl",
- "libdd-common 4.0.0",
- "libdd-ddsketch 1.0.1 (git+https://github.com/DataDog/libdatadog?rev=0a3304c6aaf84738786b670d706a01edc22dab81)",
+ "libdd-common 4.2.0",
+ "libdd-ddsketch 1.0.1 (git+https://github.com/DataDog/libdatadog?rev=48da0d82cb32b43d4cdece35b794c9bcbc275a03)",
  "libdd-shared-runtime",
  "libdd-trace-obfuscation",
- "libdd-trace-protobuf 3.0.1",
- "libdd-trace-utils 3.0.1",
+ "libdd-trace-protobuf 3.0.2",
+ "libdd-trace-utils 6.0.1",
  "rmp-serde",
  "serde",
  "tokio",
@@ -1777,7 +1777,7 @@ dependencies = [
  "http-body-util",
  "indexmap",
  "libdd-common 2.0.1",
- "libdd-tinybytes 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libdd-tinybytes 1.1.0",
  "libdd-trace-normalization 1.0.2",
  "libdd-trace-protobuf 2.0.0",
  "prost 0.14.3",
@@ -1793,8 +1793,8 @@ dependencies = [
 
 [[package]]
 name = "libdd-trace-utils"
-version = "3.0.1"
-source = "git+https://github.com/DataDog/libdatadog?rev=0a3304c6aaf84738786b670d706a01edc22dab81#0a3304c6aaf84738786b670d706a01edc22dab81"
+version = "6.0.1"
+source = "git+https://github.com/DataDog/libdatadog?rev=48da0d82cb32b43d4cdece35b794c9bcbc275a03#48da0d82cb32b43d4cdece35b794c9bcbc275a03"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -1812,10 +1812,10 @@ dependencies = [
  "indexmap",
  "libdd-capabilities",
  "libdd-capabilities-impl",
- "libdd-common 4.0.0",
- "libdd-tinybytes 1.1.0 (git+https://github.com/DataDog/libdatadog?rev=0a3304c6aaf84738786b670d706a01edc22dab81)",
+ "libdd-common 4.2.0",
+ "libdd-tinybytes 1.1.1",
  "libdd-trace-normalization 2.0.0",
- "libdd-trace-protobuf 3.0.1",
+ "libdd-trace-protobuf 3.0.2",
  "prost 0.14.3",
  "rand 0.8.6",
  "rmp",

--- a/crates/datadog-agent-config/Cargo.toml
+++ b/crates/datadog-agent-config/Cargo.toml
@@ -6,8 +6,8 @@ license.workspace = true
 
 [dependencies]
 figment = { version = "0.10", default-features = false, features = ["yaml", "env"] }
-libdd-trace-obfuscation = { git = "https://github.com/DataDog/libdatadog", rev = "0a3304c6aaf84738786b670d706a01edc22dab81" }
-libdd-trace-utils = { git = "https://github.com/DataDog/libdatadog", rev = "0a3304c6aaf84738786b670d706a01edc22dab81" }
+libdd-trace-obfuscation = { git = "https://github.com/DataDog/libdatadog", rev = "48da0d82cb32b43d4cdece35b794c9bcbc275a03" }
+libdd-trace-utils = { git = "https://github.com/DataDog/libdatadog", rev = "48da0d82cb32b43d4cdece35b794c9bcbc275a03" }
 log = { version = "0.4", default-features = false }
 serde = { version = "1.0", default-features = false, features = ["derive"] }
 serde-aux = { version = "4.7", default-features = false }

--- a/crates/datadog-metrics-collector/Cargo.toml
+++ b/crates/datadog-metrics-collector/Cargo.toml
@@ -8,7 +8,7 @@ description = "Collector to read, compute, and submit enhanced metrics in Server
 [dependencies]
 dogstatsd = { path = "../dogstatsd", default-features = true }
 tracing = { version = "0.1", default-features = false }
-libdd-common = { git = "https://github.com/DataDog/libdatadog", rev = "0a3304c6aaf84738786b670d706a01edc22dab81", default-features = false }
+libdd-common = { git = "https://github.com/DataDog/libdatadog", rev = "48da0d82cb32b43d4cdece35b794c9bcbc275a03", default-features = false }
 
 [target.'cfg(windows)'.dependencies]
 windows-sys = { version = "0.61", features = ["Win32_System_JobObjects"], optional = true, default-features = false }

--- a/crates/datadog-serverless-compat/Cargo.toml
+++ b/crates/datadog-serverless-compat/Cargo.toml
@@ -14,7 +14,7 @@ windows-enhanced-metrics = ["datadog-metrics-collector/windows-enhanced-metrics"
 datadog-logs-agent = { path = "../datadog-logs-agent" }
 datadog-metrics-collector = { path = "../datadog-metrics-collector" }
 datadog-trace-agent = { path = "../datadog-trace-agent" }
-libdd-trace-utils = { git = "https://github.com/DataDog/libdatadog", rev = "0a3304c6aaf84738786b670d706a01edc22dab81" }
+libdd-trace-utils = { git = "https://github.com/DataDog/libdatadog", rev = "48da0d82cb32b43d4cdece35b794c9bcbc275a03" }
 datadog-fips = { path = "../datadog-fips", default-features = false }
 dogstatsd = { path = "../dogstatsd", default-features = true }
 reqwest = { version = "0.12.4", default-features = false }

--- a/crates/datadog-trace-agent/Cargo.toml
+++ b/crates/datadog-trace-agent/Cargo.toml
@@ -25,16 +25,16 @@ tracing = { version = "0.1", default-features = false }
 serde = { version = "1.0.145", features = ["derive"] }
 serde_json = "1.0"
 thiserror = { version = "1.0.58", default-features = false }
-libdd-capabilities = { git = "https://github.com/DataDog/libdatadog", rev = "0a3304c6aaf84738786b670d706a01edc22dab81" }
-libdd-capabilities-impl = { git = "https://github.com/DataDog/libdatadog", rev = "0a3304c6aaf84738786b670d706a01edc22dab81" }
-libdd-common = { git = "https://github.com/DataDog/libdatadog", rev = "0a3304c6aaf84738786b670d706a01edc22dab81" }
-libdd-library-config = { git = "https://github.com/DataDog/libdatadog", rev = "0a3304c6aaf84738786b670d706a01edc22dab81" }
-libdd-trace-protobuf = { git = "https://github.com/DataDog/libdatadog", rev = "0a3304c6aaf84738786b670d706a01edc22dab81" }
-libdd-trace-stats = { git = "https://github.com/DataDog/libdatadog", rev = "0a3304c6aaf84738786b670d706a01edc22dab81" }
-libdd-trace-utils = { git = "https://github.com/DataDog/libdatadog", rev = "0a3304c6aaf84738786b670d706a01edc22dab81", features = [
+libdd-capabilities = { git = "https://github.com/DataDog/libdatadog", rev = "48da0d82cb32b43d4cdece35b794c9bcbc275a03" }
+libdd-capabilities-impl = { git = "https://github.com/DataDog/libdatadog", rev = "48da0d82cb32b43d4cdece35b794c9bcbc275a03" }
+libdd-common = { git = "https://github.com/DataDog/libdatadog", rev = "48da0d82cb32b43d4cdece35b794c9bcbc275a03" }
+libdd-library-config = { git = "https://github.com/DataDog/libdatadog", rev = "48da0d82cb32b43d4cdece35b794c9bcbc275a03" }
+libdd-trace-protobuf = { git = "https://github.com/DataDog/libdatadog", rev = "48da0d82cb32b43d4cdece35b794c9bcbc275a03" }
+libdd-trace-stats = { git = "https://github.com/DataDog/libdatadog", rev = "48da0d82cb32b43d4cdece35b794c9bcbc275a03" }
+libdd-trace-utils = { git = "https://github.com/DataDog/libdatadog", rev = "48da0d82cb32b43d4cdece35b794c9bcbc275a03", features = [
     "mini_agent",
 ] }
-libdd-trace-obfuscation = { git = "https://github.com/DataDog/libdatadog", rev = "0a3304c6aaf84738786b670d706a01edc22dab81" }
+libdd-trace-obfuscation = { git = "https://github.com/DataDog/libdatadog", rev = "48da0d82cb32b43d4cdece35b794c9bcbc275a03" }
 datadog-fips = { path = "../datadog-fips" }
 reqwest = { version = "0.12.23", features = [
     "json",
@@ -49,6 +49,6 @@ serial_test = "2.0.0"
 duplicate = "2.0.1"
 temp-env = "0.3.6"
 tempfile = "3.3.0"
-libdd-trace-utils = { git = "https://github.com/DataDog/libdatadog", rev = "0a3304c6aaf84738786b670d706a01edc22dab81", features = [
+libdd-trace-utils = { git = "https://github.com/DataDog/libdatadog", rev = "48da0d82cb32b43d4cdece35b794c9bcbc275a03", features = [
     "test-utils",
 ] }


### PR DESCRIPTION
### What does this PR do?

Bumps `libdatadog` rev across all crates from `0a3304c` to `48da0d8`.

### Motivation

The `datadog-lambda-extension` bottlecap binary bumped to `libdatadog` rev `48da0d8` in DataDog/datadog-lambda-extension#1244 for the client-computed header fix. Bottlecap is preparing to consume `datadog-agent-config` as a drop-in replacement for its in-tree config module — see the analysis in the bottlecap migration PR.

For that to work, both repos must point at the same `libdatadog` rev. The `datadog-agent-config` API exposes `libdd_trace_obfuscation::replacer::ReplaceRule` (via `apm_replace_tags`) and `libdd_trace_utils` helpers across its boundary, so a rev mismatch causes Cargo to compile two incompatible copies of those types in bottlecap's dependency graph.

### Additional Notes

This bump follows the same shape as #127 (`bump libdatadog to db05e1f`) — 4 Cargo.toml files + Cargo.lock.

### Describe how to test/QA your changes

- `cargo check --workspace` — clean
- `cargo test -p datadog-agent-config` — all 71 tests pass
- No source changes; rev bump only