### PR TITLE
feat(agent-config): make TLS provider opt-in for transitive libdd deps

### DIFF
--- a/crates/datadog-agent-config/Cargo.toml
+++ b/crates/datadog-agent-config/Cargo.toml
@@ -6,19 +6,35 @@ license.workspace = true
 
 [dependencies]
 figment = { version = "0.10", default-features = false, features = ["yaml", "env"] }
-libdd-trace-obfuscation = { git = "https://github.com/DataDog/libdatadog", rev = "48da0d82cb32b43d4cdece35b794c9bcbc275a03" }
-libdd-trace-utils = { git = "https://github.com/DataDog/libdatadog", rev = "48da0d82cb32b43d4cdece35b794c9bcbc275a03" }
+libdd-trace-obfuscation = { git = "https://github.com/DataDog/libdatadog", rev = "48da0d82cb32b43d4cdece35b794c9bcbc275a03", default-features = false }
+libdd-trace-utils = { git = "https://github.com/DataDog/libdatadog", rev = "48da0d82cb32b43d4cdece35b794c9bcbc275a03", default-features = false }
 log = { version = "0.4", default-features = false }
 serde = { version = "1.0", default-features = false, features = ["derive"] }
 serde-aux = { version = "4.7", default-features = false }
 serde_json = { version = "1.0", default-features = false, features = ["alloc"] }
 tracing = { version = "0.1", default-features = false }
 datadog-opentelemetry = { git = "https://github.com/DataDog/dd-trace-rs", rev = "f51cefc4ad24bec81b38fb2f36b1ed93f21ae913", default-features = false }
-dogstatsd = { path = "../dogstatsd" }
+dogstatsd = { path = "../dogstatsd", default-features = false }
 tokio = { version = "1.47", default-features = false, features = ["time"] }
 
 [dev-dependencies]
 figment = { version = "0.10", default-features = false, features = ["yaml", "env", "test"] }
+
+[features]
+# Disabled by default. Consumers that need a TLS provider on the transitive
+# libdatadog deps (e.g. for HTTPS proxying) must enable one of these features
+# explicitly; without that, no TLS provider is pulled in and the crate stays
+# crypto-agnostic. The two are mutually exclusive — pick whichever matches
+# your consumer's crypto policy.
+default = []
+https = [
+    "libdd-trace-utils/https",
+    "libdd-trace-obfuscation/https",
+]
+fips = [
+    "libdd-trace-utils/fips",
+    "libdd-trace-obfuscation/fips",
+]
 
 [lints.rust]
 unexpected_cfgs = { level = "warn", check-cfg = ['cfg(coverage,coverage_nightly)'] }

--- a/crates/datadog-agent-config/Cargo.toml
+++ b/crates/datadog-agent-config/Cargo.toml
@@ -24,8 +24,9 @@ figment = { version = "0.10", default-features = false, features = ["yaml", "env
 # Disabled by default. Consumers that need a TLS provider on the transitive
 # libdatadog deps (e.g. for HTTPS proxying) must enable one of these features
 # explicitly; without that, no TLS provider is pulled in and the crate stays
-# crypto-agnostic. The two are mutually exclusive — pick whichever matches
-# your consumer's crypto policy.
+# crypto-agnostic. Pick one — Cargo doesn't enforce this, but enabling both
+# (e.g. via `--all-features`) defeats the purpose since cargo unions
+# features additively, leaving both ring and aws-lc-rs in the dep graph.
 default = []
 https = [
     "libdd-trace-utils/https",


### PR DESCRIPTION
### What does this PR do?

Switch \`libdd-trace-utils\` and \`libdd-trace-obfuscation\` deps inside \`datadog-agent-config\` to \`default-features = false\`, and expose two new crate features so consumers pick the TLS provider explicitly:

- \`https\` → enables \`libdd-trace-{utils,obfuscation}/https\` (ring-backed)
- \`fips\` → enables \`libdd-trace-{utils,obfuscation}/fips\` (aws-lc-rs-backed)

The default feature set is now empty.

### Motivation

The crate itself never reaches for TLS — it only ever uses \`parse_rules_from_string\` from \`libdd-trace-obfuscation\` and a couple of URL helpers from \`libdd-trace-utils\`. But by depending on those crates with their \`default\` features (which include \`https\` and pull \`hyper-rustls\` + \`ring\`), the choice of crypto provider leaked into every downstream consumer.

This bit \`datadog-lambda-extension\` (bottlecap), which builds a FIPS-compliant variant of its binary. Bottlecap activates \`libdd-*/fips\` via its own \`fips\` feature, but because Cargo feature unification is additive, the implicit \`libdd-*/default\` pulled in via \`datadog-agent-config\` re-enabled the \`https\` (ring) path alongside, breaking FIPS dependency-graph validation (\`ring v0.17 → libdd-common feature \"https\" → hyper-rustls feature \"ring\" → rustls-webpki feature \"ring\"\`).

By making the TLS provider opt-in, \`datadog-agent-config\` becomes crypto-agnostic again. Consumers either enable \`https\` or \`fips\` depending on their build, and the FIPS branch is no longer poisoned by an implicit default.

Same treatment applied to the \`dogstatsd\` workspace dep — it's used only for \`parse_metric_namespace\`, so default features are disabled.

### Additional Notes

Existing consumers that relied on the implicit \`https\` pull from \`datadog-agent-config\` need to opt in:

\`\`\`toml
datadog-agent-config = { ..., features = [\"https\"] }   # or [\"fips\"]
\`\`\`

### Describe how to test/QA your changes

- \`cargo check -p datadog-agent-config\` — clean
- \`cargo test  -p datadog-agent-config\` — all 71 tests pass
- Verified bottlecap's FIPS dep tree is clean when \`datadog-agent-config\` is consumed with \`features = [\"fips\"]\` (no \`ring\` in the dep graph).