### PR TITLE
feat(agent-config): add dd_org_uuid for delegated auth

### DIFF
--- a/crates/datadog-agent-config/src/lib.rs
+++ b/crates/datadog-agent-config/src/lib.rs
@@ -42,6 +42,10 @@ use crate::{
 pub struct Config<E: ConfigExtension = NoExtension> {
     pub site: String,
     pub api_key: String,
+    /// Datadog organization UUID. When set, enables delegated authentication
+    /// against the Datadog SaaS auth tier without requiring an api_key in some
+    /// flows. Sourced from `DD_ORG_UUID` / `org_uuid` in datadog.yaml.
+    pub dd_org_uuid: String,
     pub log_level: LogLevel,
 
     // Timeout for the request to flush data to Datadog endpoint
@@ -160,6 +164,7 @@ impl<E: ConfigExtension> Default for Config<E> {
         Self {
             site: String::default(),
             api_key: String::default(),
+            dd_org_uuid: String::default(),
             log_level: LogLevel::default(),
             flush_timeout: 30,
 

--- a/crates/datadog-agent-config/src/sources/env.rs
+++ b/crates/datadog-agent-config/src/sources/env.rs
@@ -35,6 +35,13 @@ pub struct EnvConfig {
     /// The Datadog API key used to submit telemetry to Datadog
     #[serde(deserialize_with = "deserialize_optional_string")]
     pub api_key: Option<String>,
+    /// @env `DD_ORG_UUID`
+    ///
+    /// The Datadog organization UUID. When set, enables delegated auth so the
+    /// agent can submit telemetry without a long-lived API key. Accepts a
+    /// string or numeric form for backwards compatibility.
+    #[serde(deserialize_with = "deserialize_string_or_int")]
+    pub org_uuid: Option<String>,
     /// @env `DD_LOG_LEVEL`
     ///
     /// Minimum log level of the Datadog Agent.
@@ -372,6 +379,7 @@ fn merge_config<E: ConfigExtension>(config: &mut Config<E>, env_config: &EnvConf
     // Basic fields
     merge_string!(config, env_config, site);
     merge_string!(config, env_config, api_key);
+    merge_string!(config, dd_org_uuid, env_config, org_uuid);
     merge_option_to_value!(config, env_config, log_level);
     merge_option_to_value!(config, env_config, flush_timeout);
 
@@ -688,6 +696,7 @@ mod tests {
         let string_env_vars: &[(&str, &str)] = &[
             ("DD_SITE", "custom-site.example.com"),
             ("DD_API_KEY", "test-api-key-12345"),
+            ("DD_ORG_UUID", "00000000-0000-0000-0000-000000000001"),
             ("DD_PROXY_HTTPS", "https://proxy.example.com"),
             ("DD_HTTP_PROTOCOL", "http1"),
             ("DD_TLS_CERT_FILE", "/opt/ca-cert.pem"),
@@ -770,6 +779,7 @@ mod tests {
             // String fields (merge_string! → Config String)
             expected.site = "custom-site.example.com".to_string();
             expected.api_key = "test-api-key-12345".to_string();
+            expected.dd_org_uuid = "00000000-0000-0000-0000-000000000001".to_string();
             expected.dd_url = "https://custom-metrics.example.com".to_string();
             expected.url = "https://custom-app.example.com".to_string();
             expected.logs_config_logs_dd_url = "https://custom-logs.example.com".to_string();
@@ -954,6 +964,7 @@ mod tests {
             let expected_config = Config {
                 site: "test-site".to_string(),
                 api_key: "test-api-key".to_string(),
+                dd_org_uuid: String::default(),
                 log_level: LogLevel::Debug,
                 compression_level: 4,
                 flush_timeout: 42,
@@ -1108,6 +1119,37 @@ mod tests {
             assert_eq!(config.dogstatsd_so_rcvbuf, Some(1_048_576));
             assert_eq!(config.dogstatsd_buffer_size, Some(65507));
             assert_eq!(config.dogstatsd_queue_size, Some(2048));
+            Ok(())
+        });
+    }
+
+    #[test]
+    fn test_dd_org_uuid_from_env() {
+        figment::Jail::expect_with(|jail| {
+            jail.clear_env();
+            jail.set_env("DD_ORG_UUID", "11111111-2222-3333-4444-555555555555");
+
+            let mut config: Config = Config::default();
+            EnvConfigSource
+                .load(&mut config)
+                .expect("Failed to load config");
+
+            assert_eq!(config.dd_org_uuid, "11111111-2222-3333-4444-555555555555");
+            Ok(())
+        });
+    }
+
+    #[test]
+    fn test_dd_org_uuid_default_empty_when_unset() {
+        figment::Jail::expect_with(|jail| {
+            jail.clear_env();
+
+            let mut config: Config = Config::default();
+            EnvConfigSource
+                .load(&mut config)
+                .expect("Failed to load config");
+
+            assert!(config.dd_org_uuid.is_empty());
             Ok(())
         });
     }

--- a/crates/datadog-agent-config/src/sources/env.rs
+++ b/crates/datadog-agent-config/src/sources/env.rs
@@ -38,9 +38,8 @@ pub struct EnvConfig {
     /// @env `DD_ORG_UUID`
     ///
     /// The Datadog organization UUID. When set, enables delegated auth so the
-    /// agent can submit telemetry without a long-lived API key. Accepts a
-    /// string or numeric form for backwards compatibility.
-    #[serde(deserialize_with = "deserialize_string_or_int")]
+    /// agent can submit telemetry without a long-lived API key.
+    #[serde(deserialize_with = "deserialize_optional_string")]
     pub org_uuid: Option<String>,
     /// @env `DD_LOG_LEVEL`
     ///

--- a/crates/datadog-agent-config/src/sources/yaml.rs
+++ b/crates/datadog-agent-config/src/sources/yaml.rs
@@ -29,7 +29,10 @@ pub struct YamlConfig {
     pub site: Option<String>,
     #[serde(deserialize_with = "deserialize_optional_string")]
     pub api_key: Option<String>,
-    /// Datadog organization UUID; see env.rs for full docs.
+    /// YAML key: `org_uuid`. Datadog organization UUID. When set, enables
+    /// delegated auth so the agent can submit telemetry without a long-lived
+    /// API key. Accepts a string or numeric form for backwards compatibility.
+    /// Merges into the resolved config field `dd_org_uuid`.
     #[serde(deserialize_with = "deserialize_string_or_int")]
     pub org_uuid: Option<String>,
     #[serde(deserialize_with = "deserialize_with_default")]

--- a/crates/datadog-agent-config/src/sources/yaml.rs
+++ b/crates/datadog-agent-config/src/sources/yaml.rs
@@ -29,6 +29,9 @@ pub struct YamlConfig {
     pub site: Option<String>,
     #[serde(deserialize_with = "deserialize_optional_string")]
     pub api_key: Option<String>,
+    /// Datadog organization UUID; see env.rs for full docs.
+    #[serde(deserialize_with = "deserialize_string_or_int")]
+    pub org_uuid: Option<String>,
     #[serde(deserialize_with = "deserialize_with_default")]
     pub log_level: Option<LogLevel>,
 
@@ -410,6 +413,7 @@ fn merge_config<E: ConfigExtension>(config: &mut Config<E>, yaml_config: &YamlCo
     // Basic fields
     merge_string!(config, yaml_config, site);
     merge_string!(config, yaml_config, api_key);
+    merge_string!(config, dd_org_uuid, yaml_config, org_uuid);
     merge_option_to_value!(config, yaml_config, log_level);
     merge_option_to_value!(config, yaml_config, flush_timeout);
 
@@ -747,6 +751,7 @@ mod tests {
 # Basic fields — string fields get valid non-default values
 site: "custom-site.example.com"
 api_key: "test-api-key-12345"
+org_uuid: "00000000-0000-0000-0000-000000000001"
 log_level: [1, 2, 3]
 flush_timeout: [1, 2, 3]
 compression_level: [1, 2, 3]
@@ -858,6 +863,7 @@ otlp_config:
             let mut expected: Config = Config::default();
             expected.site = "custom-site.example.com".to_string();
             expected.api_key = "test-api-key-12345".to_string();
+            expected.dd_org_uuid = "00000000-0000-0000-0000-000000000001".to_string();
             expected.dd_url = "https://custom-metrics.example.com".to_string();
             expected.logs_config_logs_dd_url = "https://custom-logs.example.com".to_string();
             expected.apm_dd_url = "https://custom-apm.example.com".to_string();
@@ -1024,6 +1030,7 @@ otlp_config:
             let expected_config = Config {
                 site: "test-site".to_string(),
                 api_key: "test-api-key".to_string(),
+                dd_org_uuid: String::default(),
                 log_level: LogLevel::Debug,
                 flush_timeout: 42,
                 compression_level: 4,

--- a/crates/datadog-agent-config/src/sources/yaml.rs
+++ b/crates/datadog-agent-config/src/sources/yaml.rs
@@ -31,9 +31,8 @@ pub struct YamlConfig {
     pub api_key: Option<String>,
     /// YAML key: `org_uuid`. Datadog organization UUID. When set, enables
     /// delegated auth so the agent can submit telemetry without a long-lived
-    /// API key. Accepts a string or numeric form for backwards compatibility.
-    /// Merges into the resolved config field `dd_org_uuid`.
-    #[serde(deserialize_with = "deserialize_string_or_int")]
+    /// API key. Merges into the resolved config field `dd_org_uuid`.
+    #[serde(deserialize_with = "deserialize_optional_string")]
     pub org_uuid: Option<String>,
     #[serde(deserialize_with = "deserialize_with_default")]
     pub log_level: Option<LogLevel>,


### PR DESCRIPTION
## Summary

Adds a first-class \`dd_org_uuid: String\` field to the top-level \`Config\` struct in \`datadog-agent-config\`, sourced from the \`DD_ORG_UUID\` env var and the \`org_uuid\` key in \`datadog.yaml\`.

## Why

Delegated auth via Datadog Org UUID is a generic Datadog SaaS auth-tier concept — it lets a component submit telemetry without a long-lived API key, by binding to an org rather than authenticating per call. It is **not** Lambda-specific.

Today \`datadog-lambda-extension\` carries this field inside its \`LambdaConfig\` extension. As more agents/embedders adopt this crate, every one of them would need to redefine the same field. Putting it upstream lets the lambda extension (and any future consumer) drop the local copy.

## Behavior

- Field: \`Config::dd_org_uuid: String\`, defaults to empty.
- Env var: \`DD_ORG_UUID\` → \`EnvConfig::org_uuid: Option<String>\`.
- YAML key: \`org_uuid\` → \`YamlConfig::org_uuid: Option<String>\`.
- Both sources accept string or numeric form via \`deserialize_string_or_int\` for backwards compatibility.
- Source field name (\`org_uuid\`) matches the env var / yaml key. Merges into config field \`dd_org_uuid\` using the existing \`merge_string!\` macro's 4-arg renaming form — same convention the lambda extension was already using internally.

## Test plan

- [x] \`cargo test -p datadog-agent-config --all-targets\` — 73 passed (was 71; +2 new tests for default and env-var override)
- [x] \`cargo clippy -p datadog-agent-config --all-targets\` — clean
- [x] \`cargo fmt -p datadog-agent-config -- --check\` — clean
- [x] Added \`DD_ORG_UUID\` to the all-types-broken-fallback test in env.rs and the matching yaml.rs test; both pass.

## Follow-up

Once this lands and is pinned in \`datadog-lambda-extension\`, the extension can drop \`dd_org_uuid\` and \`org_uuid\` from its \`LambdaConfig\` / \`LambdaConfigSource\` and the local \`merge_string!(self, dd_org_uuid, source, org_uuid)\` call.