### PR TITLE
feat(agent-config): add logs_enabled master toggle

### DIFF
--- a/crates/datadog-agent-config/src/lib.rs
+++ b/crates/datadog-agent-config/src/lib.rs
@@ -74,6 +74,11 @@ pub struct Config<E: ConfigExtension = NoExtension> {
     pub tags: HashMap<String, String>,
 
     // Logs
+    /// Master toggle for log collection. Sourced from `DD_LOGS_ENABLED` /
+    /// `logs_enabled` in datadog.yaml. Defaults to `false` to match the
+    /// dd-agent default; consumers that want a different default should
+    /// override post-build or in their `ConfigExtension`.
+    pub logs_enabled: bool,
     pub logs_config_logs_dd_url: String,
     pub logs_config_processing_rules: Option<Vec<ProcessingRule>>,
     pub logs_config_use_compression: bool,
@@ -189,6 +194,7 @@ impl<E: ConfigExtension> Default for Config<E> {
             compression_level: 3,
 
             // Logs
+            logs_enabled: false,
             logs_config_logs_dd_url: String::default(),
             logs_config_processing_rules: None,
             logs_config_use_compression: true,

--- a/crates/datadog-agent-config/src/sources/env.rs
+++ b/crates/datadog-agent-config/src/sources/env.rs
@@ -134,6 +134,11 @@ pub struct EnvConfig {
     pub compression_level: Option<i32>,
 
     // Logs
+    /// @env `DD_LOGS_ENABLED`
+    ///
+    /// Master toggle for log collection. Default `false`.
+    #[serde(deserialize_with = "deserialize_optional_bool_from_anything")]
+    pub logs_enabled: Option<bool>,
     /// @env `DD_LOGS_CONFIG_LOGS_DD_URL`
     ///
     /// Define the endpoint and port to hit when using a proxy for logs.
@@ -403,6 +408,7 @@ fn merge_config<E: ConfigExtension>(config: &mut Config<E>, env_config: &EnvConf
     merge_option_to_value!(config, env_config, compression_level);
 
     // Logs
+    merge_option_to_value!(config, env_config, logs_enabled);
     merge_string!(config, env_config, logs_config_logs_dd_url);
     merge_option!(config, env_config, logs_config_processing_rules);
     merge_option_to_value!(config, env_config, logs_config_use_compression);
@@ -628,6 +634,7 @@ mod tests {
             ),
             // Bool
             ("DD_SKIP_SSL_VALIDATION", "not_a_bool"),
+            ("DD_LOGS_ENABLED", "not_a_bool"),
             ("DD_LOGS_CONFIG_USE_COMPRESSION", "not_a_bool"),
             (
                 "DD_APM_CONFIG_OBFUSCATION_HTTP_REMOVE_QUERY_STRING",
@@ -846,6 +853,7 @@ mod tests {
             jail.set_env("DD_COMPRESSION_LEVEL", "4");
 
             // Logs
+            jail.set_env("DD_LOGS_ENABLED", "true");
             jail.set_env("DD_LOGS_CONFIG_LOGS_DD_URL", "https://logs.datadoghq.com");
             jail.set_env(
                 "DD_LOGS_CONFIG_PROCESSING_RULES",
@@ -991,6 +999,7 @@ mod tests {
                     ("team".to_string(), "test-team".to_string()),
                     ("project".to_string(), "test-project".to_string()),
                 ]),
+                logs_enabled: true,
                 logs_config_logs_dd_url: "https://logs.datadoghq.com".to_string(),
                 logs_config_processing_rules: Some(vec![ProcessingRule {
                     kind: Kind::ExcludeAtMatch,
@@ -1118,6 +1127,37 @@ mod tests {
             assert_eq!(config.dogstatsd_so_rcvbuf, Some(1_048_576));
             assert_eq!(config.dogstatsd_buffer_size, Some(65507));
             assert_eq!(config.dogstatsd_queue_size, Some(2048));
+            Ok(())
+        });
+    }
+
+    #[test]
+    fn test_logs_enabled_from_env() {
+        figment::Jail::expect_with(|jail| {
+            jail.clear_env();
+            jail.set_env("DD_LOGS_ENABLED", "true");
+
+            let mut config: Config = Config::default();
+            EnvConfigSource
+                .load(&mut config)
+                .expect("Failed to load config");
+
+            assert!(config.logs_enabled);
+            Ok(())
+        });
+    }
+
+    #[test]
+    fn test_logs_enabled_defaults_false_when_unset() {
+        figment::Jail::expect_with(|jail| {
+            jail.clear_env();
+
+            let mut config: Config = Config::default();
+            EnvConfigSource
+                .load(&mut config)
+                .expect("Failed to load config");
+
+            assert!(!config.logs_enabled);
             Ok(())
         });
     }

--- a/crates/datadog-agent-config/src/sources/yaml.rs
+++ b/crates/datadog-agent-config/src/sources/yaml.rs
@@ -782,7 +782,7 @@ version: "v1.0.0"
 tags: 12345
 
 # Logs (nested)
-logs_enabled: true
+logs_enabled: [1, 2, 3]
 logs_config:
   logs_dd_url: "https://custom-logs.example.com"
   processing_rules: 12345
@@ -873,7 +873,7 @@ otlp_config:
             expected.api_key = "test-api-key-12345".to_string();
             expected.dd_org_uuid = "00000000-0000-0000-0000-000000000001".to_string();
             expected.dd_url = "https://custom-metrics.example.com".to_string();
-            expected.logs_enabled = true;
+            // logs_enabled was given an invalid type above → must stay at default (false)
             expected.logs_config_logs_dd_url = "https://custom-logs.example.com".to_string();
             expected.apm_dd_url = "https://custom-apm.example.com".to_string();
             // Option<String> fields

--- a/crates/datadog-agent-config/src/sources/yaml.rs
+++ b/crates/datadog-agent-config/src/sources/yaml.rs
@@ -72,6 +72,10 @@ pub struct YamlConfig {
     pub tags: HashMap<String, String>,
 
     // Logs
+    /// YAML key: `logs_enabled`. Master toggle for log collection; matches
+    /// dd-agent's top-level `logs_enabled` (default `false`).
+    #[serde(deserialize_with = "deserialize_optional_bool_from_anything")]
+    pub logs_enabled: Option<bool>,
     #[serde(deserialize_with = "deserialize_with_default")]
     pub logs_config: LogsConfig,
 
@@ -438,6 +442,7 @@ fn merge_config<E: ConfigExtension>(config: &mut Config<E>, yaml_config: &YamlCo
     merge_string!(config, yaml_config, dd_url);
 
     // Logs
+    merge_option_to_value!(config, yaml_config, logs_enabled);
     merge_string!(
         config,
         logs_config_logs_dd_url,
@@ -777,6 +782,7 @@ version: "v1.0.0"
 tags: 12345
 
 # Logs (nested)
+logs_enabled: true
 logs_config:
   logs_dd_url: "https://custom-logs.example.com"
   processing_rules: 12345
@@ -867,6 +873,7 @@ otlp_config:
             expected.api_key = "test-api-key-12345".to_string();
             expected.dd_org_uuid = "00000000-0000-0000-0000-000000000001".to_string();
             expected.dd_url = "https://custom-metrics.example.com".to_string();
+            expected.logs_enabled = true;
             expected.logs_config_logs_dd_url = "https://custom-logs.example.com".to_string();
             expected.apm_dd_url = "https://custom-apm.example.com".to_string();
             // Option<String> fields
@@ -934,6 +941,7 @@ tags:
   - "project:test-project"
 
 # Logs
+logs_enabled: true
 logs_config:
   logs_dd_url: "https://logs.datadoghq.com"
   processing_rules:
@@ -1060,6 +1068,7 @@ otlp_config:
                     ("team".to_string(), "test-team".to_string()),
                     ("project".to_string(), "test-project".to_string()),
                 ]),
+                logs_enabled: true,
                 logs_config_logs_dd_url: "https://logs.datadoghq.com".to_string(),
                 logs_config_processing_rules: Some(vec![ProcessingRule {
                     name: "test-exclude".to_string(),


### PR DESCRIPTION
## Summary

Adds the canonical dd-agent.yaml top-level \`logs_enabled: bool\` field to the upstream \`Config\` struct, sourced from \`DD_LOGS_ENABLED\` (env) and \`logs_enabled\` (datadog.yaml).

## Why

The dd-agent template ([config_template.yaml:1215-1219](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml#L1215-L1219)) documents \`logs_enabled\` / \`DD_LOGS_ENABLED\` as the master toggle for log collection. The upstream Rust crate has scoped variants (\`observability_pipelines_worker_logs_enabled\`, \`otlp_config_logs_enabled\`) but not the canonical top-level switch.

Today \`datadog-lambda-extension\` works around this by carrying \`logs_enabled\` as a source-side alias on its \`LambdaConfigSource\` that OR-merges into a separate \`serverless_logs_enabled\` field. With the toggle upstream, the extension (and any future embedder) gets a real resolved config field instead of a synthesized one. The lambda extension will keep \`serverless_logs_enabled\` for backwards compatibility with \`DD_SERVERLESS_LOGS_ENABLED\`, but call sites can check both fields directly.

## Behavior

- Field: \`Config::logs_enabled: bool\`, defaults to \`false\` (matches dd-agent).
- Env var: \`DD_LOGS_ENABLED\` → \`EnvConfig::logs_enabled: Option<bool>\`.
- YAML key: top-level \`logs_enabled\` → \`YamlConfig::logs_enabled: Option<bool>\`.
- Both deserialized via \`deserialize_optional_bool_from_anything\` (graceful fallback on bad input — same pattern as other bool fields).

## Test plan

- [x] \`cargo test -p datadog-agent-config --all-targets\` — 75 passed (was 73; +2 new tests covering env-var override + default-false-when-unset)
- [x] \`cargo clippy -p datadog-agent-config --all-targets\` — clean
- [x] \`cargo fmt -p datadog-agent-config -- --check\` — clean
- [x] Added \`DD_LOGS_ENABLED\` to the all-types-broken-fallback test in env.rs and the matching yaml.rs broken-fallback test; both pass.

## Follow-up

Once this lands and is pinned in \`datadog-lambda-extension\`, the extension can:
- Drop the \`logs_enabled\` alias source field from \`LambdaConfigSource\`.
- Drop the OR-merge in \`merge_from\`.
- Have call sites check \`config.logs_enabled || config.ext.serverless_logs_enabled\` (preserving the existing OR semantics, with the lambda default of \`true\` retained on the extension side).