### PR TITLE
chore(deps): bump quinn-proto to 0.11.15 (RUSTSEC-2026-0185)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2417,9 +2417,9 @@ dependencies = [
 
 [[package]]
 name = "quinn-proto"
-version = "0.11.14"
+version = "0.11.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
+checksum = "4fcb935c5bec503c2f0e306bdd3e58bb9029dcb14fa8d9ac76e3a5256ac0763e"
 dependencies = [
  "bytes",
  "getrandom 0.3.4",


### PR DESCRIPTION
## Overview

Fixes high-severity advisory [RUSTSEC-2026-0185](https://rustsec.org/advisories/RUSTSEC-2026-0185): *Remote memory exhaustion in quinn-proto from unbounded out-of-order stream reassembly*. Solution per the advisory is to upgrade to `>= 0.11.15`.

`quinn-proto` is pulled in transitively via `reqwest -> quinn -> quinn-proto`.

Companion downstream fix in datadog-lambda-extension: DataDog/datadog-lambda-extension#1269. Once this is merged, we can bump the rev in bottlecap to pick up the fix here too (rather than carrying the lockfile divergence).

`cargo audit` after the bump reports zero vulnerabilities and zero warnings.

## Testing

- `cargo audit` clean.