### PR TITLE
feat: implement additional metric tags for trace stats

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -473,8 +473,8 @@ dependencies = [
  "datadog-opentelemetry",
  "dogstatsd",
  "figment",
- "libdd-trace-obfuscation 5.0.0 (git+https://github.com/DataDog/libdatadog?rev=85ce322a1dcb1eda7df9bcc021223b2d1a236783)",
- "libdd-trace-utils 9.0.0 (git+https://github.com/DataDog/libdatadog?rev=85ce322a1dcb1eda7df9bcc021223b2d1a236783)",
+ "libdd-trace-obfuscation 5.0.0 (git+https://github.com/DataDog/libdatadog?rev=63ecad56152f675fb74761d60adf5a861dafb1e1)",
+ "libdd-trace-utils 9.0.0 (git+https://github.com/DataDog/libdatadog?rev=63ecad56152f675fb74761d60adf5a861dafb1e1)",
  "log",
  "serde",
  "serde-aux",
@@ -518,7 +518,7 @@ name = "datadog-metrics-collector"
 version = "0.1.0"
 dependencies = [
  "dogstatsd",
- "libdd-common 4.2.0",
+ "libdd-common 5.1.0 (git+https://github.com/DataDog/libdatadog?rev=63ecad56152f675fb74761d60adf5a861dafb1e1)",
  "tokio",
  "tracing",
  "windows-sys 0.61.2",
@@ -542,10 +542,10 @@ dependencies = [
  "libdd-capabilities-impl 3.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "libdd-common 5.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "libdd-data-pipeline",
- "libdd-library-config 3.0.0",
+ "libdd-library-config 3.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "libdd-sampling",
- "libdd-shared-runtime 2.0.0",
- "libdd-telemetry",
+ "libdd-shared-runtime 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libdd-telemetry 6.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "libdd-tinybytes 1.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "libdd-trace-utils 9.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "lru",
@@ -587,7 +587,7 @@ dependencies = [
  "datadog-metrics-collector",
  "datadog-trace-agent",
  "dogstatsd",
- "libdd-trace-utils 8.0.0",
+ "libdd-trace-utils 9.0.0 (git+https://github.com/DataDog/libdatadog?rev=63ecad56152f675fb74761d60adf5a861dafb1e1)",
  "reqwest",
  "serde_json",
  "tokio",
@@ -611,14 +611,14 @@ dependencies = [
  "hyper",
  "hyper-http-proxy",
  "hyper-util",
- "libdd-capabilities 2.0.0",
- "libdd-capabilities-impl 2.0.0",
- "libdd-common 4.2.0",
- "libdd-library-config 2.0.0",
- "libdd-trace-obfuscation 4.0.0",
- "libdd-trace-protobuf 3.0.2",
- "libdd-trace-stats 5.0.0",
- "libdd-trace-utils 8.0.0",
+ "libdd-capabilities 2.1.0 (git+https://github.com/DataDog/libdatadog?rev=63ecad56152f675fb74761d60adf5a861dafb1e1)",
+ "libdd-capabilities-impl 3.0.0 (git+https://github.com/DataDog/libdatadog?rev=63ecad56152f675fb74761d60adf5a861dafb1e1)",
+ "libdd-common 5.1.0 (git+https://github.com/DataDog/libdatadog?rev=63ecad56152f675fb74761d60adf5a861dafb1e1)",
+ "libdd-library-config 3.0.0 (git+https://github.com/DataDog/libdatadog?rev=63ecad56152f675fb74761d60adf5a861dafb1e1)",
+ "libdd-trace-obfuscation 5.0.0 (git+https://github.com/DataDog/libdatadog?rev=63ecad56152f675fb74761d60adf5a861dafb1e1)",
+ "libdd-trace-protobuf 4.0.0 (git+https://github.com/DataDog/libdatadog?rev=63ecad56152f675fb74761d60adf5a861dafb1e1)",
+ "libdd-trace-stats 6.0.0 (git+https://github.com/DataDog/libdatadog?rev=63ecad56152f675fb74761d60adf5a861dafb1e1)",
+ "libdd-trace-utils 9.0.0 (git+https://github.com/DataDog/libdatadog?rev=63ecad56152f675fb74761d60adf5a861dafb1e1)",
  "reqwest",
  "rmp-serde",
  "serde",
@@ -1242,7 +1242,6 @@ dependencies = [
  "hyper",
  "hyper-util",
  "rustls",
- "rustls-native-certs",
  "rustls-pki-types",
  "tokio",
  "tokio-rustls",
@@ -1514,17 +1513,6 @@ checksum = "b5b646652bf6661599e1da8901b3b9522896f01e736bad5f723fe7a3a27f899d"
 
 [[package]]
 name = "libdd-capabilities"
-version = "2.0.0"
-source = "git+https://github.com/DataDog/libdatadog?rev=a820699426f28cbabb3a74d87c7309d030b52e7c#a820699426f28cbabb3a74d87c7309d030b52e7c"
-dependencies = [
- "anyhow",
- "bytes",
- "http",
- "thiserror 1.0.69",
-]
-
-[[package]]
-name = "libdd-capabilities"
 version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "43a946c29c5fe7cc2adec7a66a35f7cfc138ba75c988d09a7a99c12de7d3b9a7"
@@ -1538,25 +1526,12 @@ dependencies = [
 [[package]]
 name = "libdd-capabilities"
 version = "2.1.0"
-source = "git+https://github.com/DataDog/libdatadog?rev=85ce322a1dcb1eda7df9bcc021223b2d1a236783#85ce322a1dcb1eda7df9bcc021223b2d1a236783"
+source = "git+https://github.com/DataDog/libdatadog?rev=63ecad56152f675fb74761d60adf5a861dafb1e1#63ecad56152f675fb74761d60adf5a861dafb1e1"
 dependencies = [
  "anyhow",
  "bytes",
  "http",
  "thiserror 1.0.69",
-]
-
-[[package]]
-name = "libdd-capabilities-impl"
-version = "2.0.0"
-source = "git+https://github.com/DataDog/libdatadog?rev=a820699426f28cbabb3a74d87c7309d030b52e7c#a820699426f28cbabb3a74d87c7309d030b52e7c"
-dependencies = [
- "bytes",
- "http",
- "http-body-util",
- "libdd-capabilities 2.0.0",
- "libdd-common 4.2.0",
- "tokio",
 ]
 
 [[package]]
@@ -1576,48 +1551,15 @@ dependencies = [
 [[package]]
 name = "libdd-capabilities-impl"
 version = "3.0.0"
-source = "git+https://github.com/DataDog/libdatadog?rev=85ce322a1dcb1eda7df9bcc021223b2d1a236783#85ce322a1dcb1eda7df9bcc021223b2d1a236783"
-dependencies = [
- "bytes",
- "http",
- "http-body-util",
- "libdd-capabilities 2.1.0 (git+https://github.com/DataDog/libdatadog?rev=85ce322a1dcb1eda7df9bcc021223b2d1a236783)",
- "libdd-common 5.1.0 (git+https://github.com/DataDog/libdatadog?rev=85ce322a1dcb1eda7df9bcc021223b2d1a236783)",
- "tokio",
-]
-
-[[package]]
-name = "libdd-common"
-version = "4.2.0"
-source = "git+https://github.com/DataDog/libdatadog?rev=a820699426f28cbabb3a74d87c7309d030b52e7c#a820699426f28cbabb3a74d87c7309d030b52e7c"
+source = "git+https://github.com/DataDog/libdatadog?rev=63ecad56152f675fb74761d60adf5a861dafb1e1#63ecad56152f675fb74761d60adf5a861dafb1e1"
 dependencies = [
  "anyhow",
  "bytes",
- "cc",
- "const_format",
- "futures",
- "futures-core",
- "futures-util",
- "hex",
  "http",
- "http-body",
  "http-body-util",
- "hyper",
- "hyper-rustls",
- "hyper-util",
- "libc",
- "nix",
- "pin-project",
- "regex",
- "rustls",
- "rustls-native-certs",
- "serde",
- "static_assertions",
- "thiserror 1.0.69",
+ "libdd-capabilities 2.1.0 (git+https://github.com/DataDog/libdatadog?rev=63ecad56152f675fb74761d60adf5a861dafb1e1)",
+ "libdd-common 5.1.0 (git+https://github.com/DataDog/libdatadog?rev=63ecad56152f675fb74761d60adf5a861dafb1e1)",
  "tokio",
- "tokio-rustls",
- "tower-service",
- "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -1654,7 +1596,7 @@ dependencies = [
 [[package]]
 name = "libdd-common"
 version = "5.1.0"
-source = "git+https://github.com/DataDog/libdatadog?rev=85ce322a1dcb1eda7df9bcc021223b2d1a236783#85ce322a1dcb1eda7df9bcc021223b2d1a236783"
+source = "git+https://github.com/DataDog/libdatadog?rev=63ecad56152f675fb74761d60adf5a861dafb1e1#63ecad56152f675fb74761d60adf5a861dafb1e1"
 dependencies = [
  "anyhow",
  "bytes",
@@ -1703,15 +1645,15 @@ dependencies = [
  "libdd-capabilities 2.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "libdd-capabilities-impl 3.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "libdd-common 5.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "libdd-ddsketch 1.1.0",
- "libdd-dogstatsd-client",
- "libdd-shared-runtime 2.0.0",
- "libdd-telemetry",
+ "libdd-ddsketch 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libdd-dogstatsd-client 4.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libdd-shared-runtime 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libdd-telemetry 6.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "libdd-tinybytes 1.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "libdd-trace-normalization 3.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "libdd-trace-obfuscation 5.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "libdd-trace-protobuf 4.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "libdd-trace-stats 6.0.0",
+ "libdd-trace-stats 6.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "libdd-trace-utils 9.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rmp-serde",
  "serde",
@@ -1725,8 +1667,9 @@ dependencies = [
 
 [[package]]
 name = "libdd-ddsketch"
-version = "1.0.1"
-source = "git+https://github.com/DataDog/libdatadog?rev=a820699426f28cbabb3a74d87c7309d030b52e7c#a820699426f28cbabb3a74d87c7309d030b52e7c"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a3f04a8501bc5f52f005f637beb18c900c69ad6deedb5f3104cd0a8c36bc8046"
 dependencies = [
  "prost 0.14.3",
 ]
@@ -1734,8 +1677,7 @@ dependencies = [
 [[package]]
 name = "libdd-ddsketch"
 version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a3f04a8501bc5f52f005f637beb18c900c69ad6deedb5f3104cd0a8c36bc8046"
+source = "git+https://github.com/DataDog/libdatadog?rev=63ecad56152f675fb74761d60adf5a861dafb1e1#63ecad56152f675fb74761d60adf5a861dafb1e1"
 dependencies = [
  "prost 0.14.3",
 ]
@@ -1755,13 +1697,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "libdd-dogstatsd-client"
+version = "4.0.0"
+source = "git+https://github.com/DataDog/libdatadog?rev=63ecad56152f675fb74761d60adf5a861dafb1e1#63ecad56152f675fb74761d60adf5a861dafb1e1"
+dependencies = [
+ "anyhow",
+ "cadence",
+ "http",
+ "libdd-common 5.1.0 (git+https://github.com/DataDog/libdatadog?rev=63ecad56152f675fb74761d60adf5a861dafb1e1)",
+ "serde",
+ "tracing",
+]
+
+[[package]]
 name = "libdd-library-config"
-version = "2.0.0"
-source = "git+https://github.com/DataDog/libdatadog?rev=a820699426f28cbabb3a74d87c7309d030b52e7c#a820699426f28cbabb3a74d87c7309d030b52e7c"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab46ec324c1b916ca06c4a369da171a08eb9f112620e6f6f004860e589892715"
 dependencies = [
  "anyhow",
  "libc",
- "libdd-trace-protobuf 3.0.2",
+ "libdd-trace-protobuf 4.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "memfd",
  "prost 0.14.3",
  "rand 0.8.6",
@@ -1774,12 +1730,11 @@ dependencies = [
 [[package]]
 name = "libdd-library-config"
 version = "3.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab46ec324c1b916ca06c4a369da171a08eb9f112620e6f6f004860e589892715"
+source = "git+https://github.com/DataDog/libdatadog?rev=63ecad56152f675fb74761d60adf5a861dafb1e1#63ecad56152f675fb74761d60adf5a861dafb1e1"
 dependencies = [
  "anyhow",
  "libc",
- "libdd-trace-protobuf 4.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libdd-trace-protobuf 4.0.0 (git+https://github.com/DataDog/libdatadog?rev=63ecad56152f675fb74761d60adf5a861dafb1e1)",
  "memfd",
  "prost 0.14.3",
  "rand 0.8.6",
@@ -1803,23 +1758,6 @@ dependencies = [
 
 [[package]]
 name = "libdd-shared-runtime"
-version = "1.0.0"
-source = "git+https://github.com/DataDog/libdatadog?rev=a820699426f28cbabb3a74d87c7309d030b52e7c#a820699426f28cbabb3a74d87c7309d030b52e7c"
-dependencies = [
- "async-trait",
- "futures",
- "futures-util",
- "libdd-capabilities 2.0.0",
- "libdd-capabilities-impl 2.0.0",
- "libdd-common 4.2.0",
- "tokio",
- "tokio-util",
- "tracing",
- "wasm-bindgen-futures",
-]
-
-[[package]]
-name = "libdd-shared-runtime"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bab1ad16a0bfcf1ce826e2314c162b04daf4324c71da5a28583ea40e76be8772"
@@ -1830,6 +1768,23 @@ dependencies = [
  "libdd-capabilities 2.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "libdd-capabilities-impl 3.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "libdd-common 5.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio",
+ "tokio-util",
+ "tracing",
+ "wasm-bindgen-futures",
+]
+
+[[package]]
+name = "libdd-shared-runtime"
+version = "2.0.0"
+source = "git+https://github.com/DataDog/libdatadog?rev=63ecad56152f675fb74761d60adf5a861dafb1e1#63ecad56152f675fb74761d60adf5a861dafb1e1"
+dependencies = [
+ "async-trait",
+ "futures",
+ "futures-util",
+ "libdd-capabilities 2.1.0 (git+https://github.com/DataDog/libdatadog?rev=63ecad56152f675fb74761d60adf5a861dafb1e1)",
+ "libdd-capabilities-impl 3.0.0 (git+https://github.com/DataDog/libdatadog?rev=63ecad56152f675fb74761d60adf5a861dafb1e1)",
+ "libdd-common 5.1.0 (git+https://github.com/DataDog/libdatadog?rev=63ecad56152f675fb74761d60adf5a861dafb1e1)",
  "tokio",
  "tokio-util",
  "tracing",
@@ -1852,8 +1807,8 @@ dependencies = [
  "http-body-util",
  "libc",
  "libdd-common 5.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "libdd-ddsketch 1.1.0",
- "libdd-shared-runtime 2.0.0",
+ "libdd-ddsketch 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libdd-shared-runtime 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde",
  "serde_json",
  "sys-info",
@@ -1861,6 +1816,35 @@ dependencies = [
  "tokio-util",
  "tracing",
  "uuid",
+ "winver",
+]
+
+[[package]]
+name = "libdd-telemetry"
+version = "6.0.0"
+source = "git+https://github.com/DataDog/libdatadog?rev=63ecad56152f675fb74761d60adf5a861dafb1e1#63ecad56152f675fb74761d60adf5a861dafb1e1"
+dependencies = [
+ "anyhow",
+ "async-trait",
+ "base64 0.22.1",
+ "bytes",
+ "futures",
+ "getrandom 0.2.17",
+ "hashbrown 0.15.5",
+ "http",
+ "libc",
+ "libdd-capabilities 2.1.0 (git+https://github.com/DataDog/libdatadog?rev=63ecad56152f675fb74761d60adf5a861dafb1e1)",
+ "libdd-common 5.1.0 (git+https://github.com/DataDog/libdatadog?rev=63ecad56152f675fb74761d60adf5a861dafb1e1)",
+ "libdd-ddsketch 1.1.0 (git+https://github.com/DataDog/libdatadog?rev=63ecad56152f675fb74761d60adf5a861dafb1e1)",
+ "libdd-shared-runtime 2.0.0 (git+https://github.com/DataDog/libdatadog?rev=63ecad56152f675fb74761d60adf5a861dafb1e1)",
+ "serde",
+ "serde_json",
+ "sys-info",
+ "tokio",
+ "tokio-util",
+ "tracing",
+ "uuid",
+ "web-time",
  "winver",
 ]
 
@@ -1876,26 +1860,9 @@ dependencies = [
 [[package]]
 name = "libdd-tinybytes"
 version = "1.1.1"
-source = "git+https://github.com/DataDog/libdatadog?rev=85ce322a1dcb1eda7df9bcc021223b2d1a236783#85ce322a1dcb1eda7df9bcc021223b2d1a236783"
+source = "git+https://github.com/DataDog/libdatadog?rev=63ecad56152f675fb74761d60adf5a861dafb1e1#63ecad56152f675fb74761d60adf5a861dafb1e1"
 dependencies = [
  "serde",
-]
-
-[[package]]
-name = "libdd-tinybytes"
-version = "1.1.1"
-source = "git+https://github.com/DataDog/libdatadog?rev=a820699426f28cbabb3a74d87c7309d030b52e7c#a820699426f28cbabb3a74d87c7309d030b52e7c"
-dependencies = [
- "serde",
-]
-
-[[package]]
-name = "libdd-trace-normalization"
-version = "2.0.0"
-source = "git+https://github.com/DataDog/libdatadog?rev=a820699426f28cbabb3a74d87c7309d030b52e7c#a820699426f28cbabb3a74d87c7309d030b52e7c"
-dependencies = [
- "anyhow",
- "libdd-trace-protobuf 3.0.2",
 ]
 
 [[package]]
@@ -1911,26 +1878,10 @@ dependencies = [
 [[package]]
 name = "libdd-trace-normalization"
 version = "3.0.0"
-source = "git+https://github.com/DataDog/libdatadog?rev=85ce322a1dcb1eda7df9bcc021223b2d1a236783#85ce322a1dcb1eda7df9bcc021223b2d1a236783"
+source = "git+https://github.com/DataDog/libdatadog?rev=63ecad56152f675fb74761d60adf5a861dafb1e1#63ecad56152f675fb74761d60adf5a861dafb1e1"
 dependencies = [
  "anyhow",
- "libdd-trace-protobuf 4.0.0 (git+https://github.com/DataDog/libdatadog?rev=85ce322a1dcb1eda7df9bcc021223b2d1a236783)",
-]
-
-[[package]]
-name = "libdd-trace-obfuscation"
-version = "4.0.0"
-source = "git+https://github.com/DataDog/libdatadog?rev=a820699426f28cbabb3a74d87c7309d030b52e7c#a820699426f28cbabb3a74d87c7309d030b52e7c"
-dependencies = [
- "anyhow",
- "fluent-uri",
- "libdd-common 4.2.0",
- "libdd-trace-protobuf 3.0.2",
- "libdd-trace-utils 8.0.0",
- "log",
- "percent-encoding",
- "serde",
- "serde_json",
+ "libdd-trace-protobuf 4.0.0 (git+https://github.com/DataDog/libdatadog?rev=63ecad56152f675fb74761d60adf5a861dafb1e1)",
 ]
 
 [[package]]
@@ -1953,27 +1904,17 @@ dependencies = [
 [[package]]
 name = "libdd-trace-obfuscation"
 version = "5.0.0"
-source = "git+https://github.com/DataDog/libdatadog?rev=85ce322a1dcb1eda7df9bcc021223b2d1a236783#85ce322a1dcb1eda7df9bcc021223b2d1a236783"
+source = "git+https://github.com/DataDog/libdatadog?rev=63ecad56152f675fb74761d60adf5a861dafb1e1#63ecad56152f675fb74761d60adf5a861dafb1e1"
 dependencies = [
  "anyhow",
  "fluent-uri",
- "libdd-common 5.1.0 (git+https://github.com/DataDog/libdatadog?rev=85ce322a1dcb1eda7df9bcc021223b2d1a236783)",
- "libdd-trace-protobuf 4.0.0 (git+https://github.com/DataDog/libdatadog?rev=85ce322a1dcb1eda7df9bcc021223b2d1a236783)",
- "libdd-trace-utils 9.0.0 (git+https://github.com/DataDog/libdatadog?rev=85ce322a1dcb1eda7df9bcc021223b2d1a236783)",
+ "libdd-common 5.1.0 (git+https://github.com/DataDog/libdatadog?rev=63ecad56152f675fb74761d60adf5a861dafb1e1)",
+ "libdd-trace-protobuf 4.0.0 (git+https://github.com/DataDog/libdatadog?rev=63ecad56152f675fb74761d60adf5a861dafb1e1)",
+ "libdd-trace-utils 9.0.0 (git+https://github.com/DataDog/libdatadog?rev=63ecad56152f675fb74761d60adf5a861dafb1e1)",
  "log",
  "percent-encoding",
  "serde",
  "serde_json",
-]
-
-[[package]]
-name = "libdd-trace-protobuf"
-version = "3.0.2"
-source = "git+https://github.com/DataDog/libdatadog?rev=a820699426f28cbabb3a74d87c7309d030b52e7c#a820699426f28cbabb3a74d87c7309d030b52e7c"
-dependencies = [
- "prost 0.14.3",
- "serde",
- "serde_bytes",
 ]
 
 [[package]]
@@ -1990,36 +1931,11 @@ dependencies = [
 [[package]]
 name = "libdd-trace-protobuf"
 version = "4.0.0"
-source = "git+https://github.com/DataDog/libdatadog?rev=85ce322a1dcb1eda7df9bcc021223b2d1a236783#85ce322a1dcb1eda7df9bcc021223b2d1a236783"
+source = "git+https://github.com/DataDog/libdatadog?rev=63ecad56152f675fb74761d60adf5a861dafb1e1#63ecad56152f675fb74761d60adf5a861dafb1e1"
 dependencies = [
  "prost 0.14.3",
  "serde",
  "serde_bytes",
-]
-
-[[package]]
-name = "libdd-trace-stats"
-version = "5.0.0"
-source = "git+https://github.com/DataDog/libdatadog?rev=a820699426f28cbabb3a74d87c7309d030b52e7c#a820699426f28cbabb3a74d87c7309d030b52e7c"
-dependencies = [
- "anyhow",
- "arc-swap",
- "async-trait",
- "hashbrown 0.15.5",
- "http",
- "libdd-capabilities 2.0.0",
- "libdd-capabilities-impl 2.0.0",
- "libdd-common 4.2.0",
- "libdd-ddsketch 1.0.1",
- "libdd-shared-runtime 1.0.0",
- "libdd-trace-obfuscation 4.0.0",
- "libdd-trace-protobuf 3.0.2",
- "libdd-trace-utils 8.0.0",
- "rmp-serde",
- "serde",
- "tokio",
- "tokio-util",
- "tracing",
 ]
 
 [[package]]
@@ -2036,10 +1952,10 @@ dependencies = [
  "libdd-capabilities 2.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "libdd-capabilities-impl 3.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "libdd-common 5.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "libdd-ddsketch 1.1.0",
- "libdd-dogstatsd-client",
- "libdd-shared-runtime 2.0.0",
- "libdd-telemetry",
+ "libdd-ddsketch 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libdd-dogstatsd-client 4.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libdd-shared-runtime 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libdd-telemetry 6.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "libdd-trace-obfuscation 5.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "libdd-trace-protobuf 4.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "libdd-trace-utils 9.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2051,41 +1967,32 @@ dependencies = [
 ]
 
 [[package]]
-name = "libdd-trace-utils"
-version = "8.0.0"
-source = "git+https://github.com/DataDog/libdatadog?rev=a820699426f28cbabb3a74d87c7309d030b52e7c#a820699426f28cbabb3a74d87c7309d030b52e7c"
+name = "libdd-trace-stats"
+version = "6.0.0"
+source = "git+https://github.com/DataDog/libdatadog?rev=63ecad56152f675fb74761d60adf5a861dafb1e1#63ecad56152f675fb74761d60adf5a861dafb1e1"
 dependencies = [
  "anyhow",
- "base64 0.22.1",
- "bytes",
- "cargo-platform",
- "cargo_metadata",
- "flate2",
+ "arc-swap",
+ "async-trait",
  "futures",
- "getrandom 0.2.17",
+ "hashbrown 0.15.5",
  "http",
- "http-body",
- "http-body-util",
- "httpmock",
- "hyper",
- "indexmap",
- "libdd-capabilities 2.0.0",
- "libdd-capabilities-impl 2.0.0",
- "libdd-common 4.2.0",
- "libdd-tinybytes 1.1.1 (git+https://github.com/DataDog/libdatadog?rev=a820699426f28cbabb3a74d87c7309d030b52e7c)",
- "libdd-trace-normalization 2.0.0",
- "libdd-trace-protobuf 3.0.2",
- "prost 0.14.3",
- "rand 0.8.6",
- "rmp",
+ "libdd-capabilities 2.1.0 (git+https://github.com/DataDog/libdatadog?rev=63ecad56152f675fb74761d60adf5a861dafb1e1)",
+ "libdd-capabilities-impl 3.0.0 (git+https://github.com/DataDog/libdatadog?rev=63ecad56152f675fb74761d60adf5a861dafb1e1)",
+ "libdd-common 5.1.0 (git+https://github.com/DataDog/libdatadog?rev=63ecad56152f675fb74761d60adf5a861dafb1e1)",
+ "libdd-ddsketch 1.1.0 (git+https://github.com/DataDog/libdatadog?rev=63ecad56152f675fb74761d60adf5a861dafb1e1)",
+ "libdd-dogstatsd-client 4.0.0 (git+https://github.com/DataDog/libdatadog?rev=63ecad56152f675fb74761d60adf5a861dafb1e1)",
+ "libdd-shared-runtime 2.0.0 (git+https://github.com/DataDog/libdatadog?rev=63ecad56152f675fb74761d60adf5a861dafb1e1)",
+ "libdd-telemetry 6.0.0 (git+https://github.com/DataDog/libdatadog?rev=63ecad56152f675fb74761d60adf5a861dafb1e1)",
+ "libdd-trace-obfuscation 5.0.0 (git+https://github.com/DataDog/libdatadog?rev=63ecad56152f675fb74761d60adf5a861dafb1e1)",
+ "libdd-trace-protobuf 4.0.0 (git+https://github.com/DataDog/libdatadog?rev=63ecad56152f675fb74761d60adf5a861dafb1e1)",
+ "libdd-trace-utils 9.0.0 (git+https://github.com/DataDog/libdatadog?rev=63ecad56152f675fb74761d60adf5a861dafb1e1)",
  "rmp-serde",
- "rmpv",
  "serde",
- "serde_json",
  "tokio",
+ "tokio-util",
  "tracing",
- "urlencoding",
- "zstd",
+ "web-time",
 ]
 
 [[package]]
@@ -2127,24 +2034,30 @@ dependencies = [
 [[package]]
 name = "libdd-trace-utils"
 version = "9.0.0"
-source = "git+https://github.com/DataDog/libdatadog?rev=85ce322a1dcb1eda7df9bcc021223b2d1a236783#85ce322a1dcb1eda7df9bcc021223b2d1a236783"
+source = "git+https://github.com/DataDog/libdatadog?rev=63ecad56152f675fb74761d60adf5a861dafb1e1#63ecad56152f675fb74761d60adf5a861dafb1e1"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
  "bytes",
+ "cargo-platform",
+ "cargo_metadata",
+ "flate2",
  "futures",
  "getrandom 0.2.17",
  "hex",
  "http",
  "http-body",
  "http-body-util",
+ "httpmock",
+ "hyper",
  "indexmap",
- "libdd-capabilities 2.1.0 (git+https://github.com/DataDog/libdatadog?rev=85ce322a1dcb1eda7df9bcc021223b2d1a236783)",
- "libdd-capabilities-impl 3.0.0 (git+https://github.com/DataDog/libdatadog?rev=85ce322a1dcb1eda7df9bcc021223b2d1a236783)",
- "libdd-common 5.1.0 (git+https://github.com/DataDog/libdatadog?rev=85ce322a1dcb1eda7df9bcc021223b2d1a236783)",
- "libdd-tinybytes 1.1.1 (git+https://github.com/DataDog/libdatadog?rev=85ce322a1dcb1eda7df9bcc021223b2d1a236783)",
- "libdd-trace-normalization 3.0.0 (git+https://github.com/DataDog/libdatadog?rev=85ce322a1dcb1eda7df9bcc021223b2d1a236783)",
- "libdd-trace-protobuf 4.0.0 (git+https://github.com/DataDog/libdatadog?rev=85ce322a1dcb1eda7df9bcc021223b2d1a236783)",
+ "itoa",
+ "libdd-capabilities 2.1.0 (git+https://github.com/DataDog/libdatadog?rev=63ecad56152f675fb74761d60adf5a861dafb1e1)",
+ "libdd-capabilities-impl 3.0.0 (git+https://github.com/DataDog/libdatadog?rev=63ecad56152f675fb74761d60adf5a861dafb1e1)",
+ "libdd-common 5.1.0 (git+https://github.com/DataDog/libdatadog?rev=63ecad56152f675fb74761d60adf5a861dafb1e1)",
+ "libdd-tinybytes 1.1.1 (git+https://github.com/DataDog/libdatadog?rev=63ecad56152f675fb74761d60adf5a861dafb1e1)",
+ "libdd-trace-normalization 3.0.0 (git+https://github.com/DataDog/libdatadog?rev=63ecad56152f675fb74761d60adf5a861dafb1e1)",
+ "libdd-trace-protobuf 4.0.0 (git+https://github.com/DataDog/libdatadog?rev=63ecad56152f675fb74761d60adf5a861dafb1e1)",
  "prost 0.14.3",
  "rand 0.8.6",
  "rmp",
@@ -2157,6 +2070,8 @@ dependencies = [
  "thin-vec",
  "tokio",
  "tracing",
+ "urlencoding",
+ "zstd",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -473,8 +473,8 @@ dependencies = [
  "datadog-opentelemetry",
  "dogstatsd",
  "figment",
- "libdd-trace-obfuscation 5.0.0 (git+https://github.com/DataDog/libdatadog?rev=63ecad56152f675fb74761d60adf5a861dafb1e1)",
- "libdd-trace-utils 9.0.0 (git+https://github.com/DataDog/libdatadog?rev=63ecad56152f675fb74761d60adf5a861dafb1e1)",
+ "libdd-trace-obfuscation 5.0.0 (git+https://github.com/DataDog/libdatadog?rev=72fa86854c823361b7d234545f1a2f2d21f944fe)",
+ "libdd-trace-utils 9.0.0 (git+https://github.com/DataDog/libdatadog?rev=72fa86854c823361b7d234545f1a2f2d21f944fe)",
  "log",
  "serde",
  "serde-aux",
@@ -518,7 +518,7 @@ name = "datadog-metrics-collector"
 version = "0.1.0"
 dependencies = [
  "dogstatsd",
- "libdd-common 5.1.0 (git+https://github.com/DataDog/libdatadog?rev=63ecad56152f675fb74761d60adf5a861dafb1e1)",
+ "libdd-common 5.1.0 (git+https://github.com/DataDog/libdatadog?rev=72fa86854c823361b7d234545f1a2f2d21f944fe)",
  "tokio",
  "tracing",
  "windows-sys 0.61.2",
@@ -587,7 +587,7 @@ dependencies = [
  "datadog-metrics-collector",
  "datadog-trace-agent",
  "dogstatsd",
- "libdd-trace-utils 9.0.0 (git+https://github.com/DataDog/libdatadog?rev=63ecad56152f675fb74761d60adf5a861dafb1e1)",
+ "libdd-trace-utils 9.0.0 (git+https://github.com/DataDog/libdatadog?rev=72fa86854c823361b7d234545f1a2f2d21f944fe)",
  "reqwest",
  "serde_json",
  "tokio",
@@ -611,14 +611,14 @@ dependencies = [
  "hyper",
  "hyper-http-proxy",
  "hyper-util",
- "libdd-capabilities 2.1.0 (git+https://github.com/DataDog/libdatadog?rev=63ecad56152f675fb74761d60adf5a861dafb1e1)",
- "libdd-capabilities-impl 3.0.0 (git+https://github.com/DataDog/libdatadog?rev=63ecad56152f675fb74761d60adf5a861dafb1e1)",
- "libdd-common 5.1.0 (git+https://github.com/DataDog/libdatadog?rev=63ecad56152f675fb74761d60adf5a861dafb1e1)",
- "libdd-library-config 3.0.0 (git+https://github.com/DataDog/libdatadog?rev=63ecad56152f675fb74761d60adf5a861dafb1e1)",
- "libdd-trace-obfuscation 5.0.0 (git+https://github.com/DataDog/libdatadog?rev=63ecad56152f675fb74761d60adf5a861dafb1e1)",
- "libdd-trace-protobuf 4.0.0 (git+https://github.com/DataDog/libdatadog?rev=63ecad56152f675fb74761d60adf5a861dafb1e1)",
- "libdd-trace-stats 6.0.0 (git+https://github.com/DataDog/libdatadog?rev=63ecad56152f675fb74761d60adf5a861dafb1e1)",
- "libdd-trace-utils 9.0.0 (git+https://github.com/DataDog/libdatadog?rev=63ecad56152f675fb74761d60adf5a861dafb1e1)",
+ "libdd-capabilities 2.1.0 (git+https://github.com/DataDog/libdatadog?rev=72fa86854c823361b7d234545f1a2f2d21f944fe)",
+ "libdd-capabilities-impl 3.0.0 (git+https://github.com/DataDog/libdatadog?rev=72fa86854c823361b7d234545f1a2f2d21f944fe)",
+ "libdd-common 5.1.0 (git+https://github.com/DataDog/libdatadog?rev=72fa86854c823361b7d234545f1a2f2d21f944fe)",
+ "libdd-library-config 3.0.0 (git+https://github.com/DataDog/libdatadog?rev=72fa86854c823361b7d234545f1a2f2d21f944fe)",
+ "libdd-trace-obfuscation 5.0.0 (git+https://github.com/DataDog/libdatadog?rev=72fa86854c823361b7d234545f1a2f2d21f944fe)",
+ "libdd-trace-protobuf 4.0.0 (git+https://github.com/DataDog/libdatadog?rev=72fa86854c823361b7d234545f1a2f2d21f944fe)",
+ "libdd-trace-stats 6.0.0 (git+https://github.com/DataDog/libdatadog?rev=72fa86854c823361b7d234545f1a2f2d21f944fe)",
+ "libdd-trace-utils 9.0.0 (git+https://github.com/DataDog/libdatadog?rev=72fa86854c823361b7d234545f1a2f2d21f944fe)",
  "reqwest",
  "rmp-serde",
  "serde",
@@ -1526,10 +1526,12 @@ dependencies = [
 [[package]]
 name = "libdd-capabilities"
 version = "2.1.0"
-source = "git+https://github.com/DataDog/libdatadog?rev=63ecad56152f675fb74761d60adf5a861dafb1e1#63ecad56152f675fb74761d60adf5a861dafb1e1"
+source = "git+https://github.com/DataDog/libdatadog?rev=72fa86854c823361b7d234545f1a2f2d21f944fe#72fa86854c823361b7d234545f1a2f2d21f944fe"
 dependencies = [
  "anyhow",
  "bytes",
+ "futures-channel",
+ "futures-util",
  "http",
  "thiserror 1.0.69",
 ]
@@ -1551,14 +1553,14 @@ dependencies = [
 [[package]]
 name = "libdd-capabilities-impl"
 version = "3.0.0"
-source = "git+https://github.com/DataDog/libdatadog?rev=63ecad56152f675fb74761d60adf5a861dafb1e1#63ecad56152f675fb74761d60adf5a861dafb1e1"
+source = "git+https://github.com/DataDog/libdatadog?rev=72fa86854c823361b7d234545f1a2f2d21f944fe#72fa86854c823361b7d234545f1a2f2d21f944fe"
 dependencies = [
  "anyhow",
  "bytes",
  "http",
  "http-body-util",
- "libdd-capabilities 2.1.0 (git+https://github.com/DataDog/libdatadog?rev=63ecad56152f675fb74761d60adf5a861dafb1e1)",
- "libdd-common 5.1.0 (git+https://github.com/DataDog/libdatadog?rev=63ecad56152f675fb74761d60adf5a861dafb1e1)",
+ "libdd-capabilities 2.1.0 (git+https://github.com/DataDog/libdatadog?rev=72fa86854c823361b7d234545f1a2f2d21f944fe)",
+ "libdd-common 5.1.0 (git+https://github.com/DataDog/libdatadog?rev=72fa86854c823361b7d234545f1a2f2d21f944fe)",
  "tokio",
 ]
 
@@ -1596,7 +1598,7 @@ dependencies = [
 [[package]]
 name = "libdd-common"
 version = "5.1.0"
-source = "git+https://github.com/DataDog/libdatadog?rev=63ecad56152f675fb74761d60adf5a861dafb1e1#63ecad56152f675fb74761d60adf5a861dafb1e1"
+source = "git+https://github.com/DataDog/libdatadog?rev=72fa86854c823361b7d234545f1a2f2d21f944fe#72fa86854c823361b7d234545f1a2f2d21f944fe"
 dependencies = [
  "anyhow",
  "bytes",
@@ -1677,7 +1679,7 @@ dependencies = [
 [[package]]
 name = "libdd-ddsketch"
 version = "1.1.0"
-source = "git+https://github.com/DataDog/libdatadog?rev=63ecad56152f675fb74761d60adf5a861dafb1e1#63ecad56152f675fb74761d60adf5a861dafb1e1"
+source = "git+https://github.com/DataDog/libdatadog?rev=72fa86854c823361b7d234545f1a2f2d21f944fe#72fa86854c823361b7d234545f1a2f2d21f944fe"
 dependencies = [
  "prost 0.14.3",
 ]
@@ -1699,12 +1701,12 @@ dependencies = [
 [[package]]
 name = "libdd-dogstatsd-client"
 version = "4.0.0"
-source = "git+https://github.com/DataDog/libdatadog?rev=63ecad56152f675fb74761d60adf5a861dafb1e1#63ecad56152f675fb74761d60adf5a861dafb1e1"
+source = "git+https://github.com/DataDog/libdatadog?rev=72fa86854c823361b7d234545f1a2f2d21f944fe#72fa86854c823361b7d234545f1a2f2d21f944fe"
 dependencies = [
  "anyhow",
  "cadence",
  "http",
- "libdd-common 5.1.0 (git+https://github.com/DataDog/libdatadog?rev=63ecad56152f675fb74761d60adf5a861dafb1e1)",
+ "libdd-common 5.1.0 (git+https://github.com/DataDog/libdatadog?rev=72fa86854c823361b7d234545f1a2f2d21f944fe)",
  "serde",
  "tracing",
 ]
@@ -1730,11 +1732,11 @@ dependencies = [
 [[package]]
 name = "libdd-library-config"
 version = "3.0.0"
-source = "git+https://github.com/DataDog/libdatadog?rev=63ecad56152f675fb74761d60adf5a861dafb1e1#63ecad56152f675fb74761d60adf5a861dafb1e1"
+source = "git+https://github.com/DataDog/libdatadog?rev=72fa86854c823361b7d234545f1a2f2d21f944fe#72fa86854c823361b7d234545f1a2f2d21f944fe"
 dependencies = [
  "anyhow",
  "libc",
- "libdd-trace-protobuf 4.0.0 (git+https://github.com/DataDog/libdatadog?rev=63ecad56152f675fb74761d60adf5a861dafb1e1)",
+ "libdd-trace-protobuf 4.0.0 (git+https://github.com/DataDog/libdatadog?rev=72fa86854c823361b7d234545f1a2f2d21f944fe)",
  "memfd",
  "prost 0.14.3",
  "rand 0.8.6",
@@ -1777,14 +1779,14 @@ dependencies = [
 [[package]]
 name = "libdd-shared-runtime"
 version = "2.0.0"
-source = "git+https://github.com/DataDog/libdatadog?rev=63ecad56152f675fb74761d60adf5a861dafb1e1#63ecad56152f675fb74761d60adf5a861dafb1e1"
+source = "git+https://github.com/DataDog/libdatadog?rev=72fa86854c823361b7d234545f1a2f2d21f944fe#72fa86854c823361b7d234545f1a2f2d21f944fe"
 dependencies = [
  "async-trait",
  "futures",
  "futures-util",
- "libdd-capabilities 2.1.0 (git+https://github.com/DataDog/libdatadog?rev=63ecad56152f675fb74761d60adf5a861dafb1e1)",
- "libdd-capabilities-impl 3.0.0 (git+https://github.com/DataDog/libdatadog?rev=63ecad56152f675fb74761d60adf5a861dafb1e1)",
- "libdd-common 5.1.0 (git+https://github.com/DataDog/libdatadog?rev=63ecad56152f675fb74761d60adf5a861dafb1e1)",
+ "libdd-capabilities 2.1.0 (git+https://github.com/DataDog/libdatadog?rev=72fa86854c823361b7d234545f1a2f2d21f944fe)",
+ "libdd-capabilities-impl 3.0.0 (git+https://github.com/DataDog/libdatadog?rev=72fa86854c823361b7d234545f1a2f2d21f944fe)",
+ "libdd-common 5.1.0 (git+https://github.com/DataDog/libdatadog?rev=72fa86854c823361b7d234545f1a2f2d21f944fe)",
  "tokio",
  "tokio-util",
  "tracing",
@@ -1822,7 +1824,7 @@ dependencies = [
 [[package]]
 name = "libdd-telemetry"
 version = "6.0.0"
-source = "git+https://github.com/DataDog/libdatadog?rev=63ecad56152f675fb74761d60adf5a861dafb1e1#63ecad56152f675fb74761d60adf5a861dafb1e1"
+source = "git+https://github.com/DataDog/libdatadog?rev=72fa86854c823361b7d234545f1a2f2d21f944fe#72fa86854c823361b7d234545f1a2f2d21f944fe"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1833,10 +1835,10 @@ dependencies = [
  "hashbrown 0.15.5",
  "http",
  "libc",
- "libdd-capabilities 2.1.0 (git+https://github.com/DataDog/libdatadog?rev=63ecad56152f675fb74761d60adf5a861dafb1e1)",
- "libdd-common 5.1.0 (git+https://github.com/DataDog/libdatadog?rev=63ecad56152f675fb74761d60adf5a861dafb1e1)",
- "libdd-ddsketch 1.1.0 (git+https://github.com/DataDog/libdatadog?rev=63ecad56152f675fb74761d60adf5a861dafb1e1)",
- "libdd-shared-runtime 2.0.0 (git+https://github.com/DataDog/libdatadog?rev=63ecad56152f675fb74761d60adf5a861dafb1e1)",
+ "libdd-capabilities 2.1.0 (git+https://github.com/DataDog/libdatadog?rev=72fa86854c823361b7d234545f1a2f2d21f944fe)",
+ "libdd-common 5.1.0 (git+https://github.com/DataDog/libdatadog?rev=72fa86854c823361b7d234545f1a2f2d21f944fe)",
+ "libdd-ddsketch 1.1.0 (git+https://github.com/DataDog/libdatadog?rev=72fa86854c823361b7d234545f1a2f2d21f944fe)",
+ "libdd-shared-runtime 2.0.0 (git+https://github.com/DataDog/libdatadog?rev=72fa86854c823361b7d234545f1a2f2d21f944fe)",
  "serde",
  "serde_json",
  "sys-info",
@@ -1860,7 +1862,7 @@ dependencies = [
 [[package]]
 name = "libdd-tinybytes"
 version = "1.1.1"
-source = "git+https://github.com/DataDog/libdatadog?rev=63ecad56152f675fb74761d60adf5a861dafb1e1#63ecad56152f675fb74761d60adf5a861dafb1e1"
+source = "git+https://github.com/DataDog/libdatadog?rev=72fa86854c823361b7d234545f1a2f2d21f944fe#72fa86854c823361b7d234545f1a2f2d21f944fe"
 dependencies = [
  "serde",
 ]
@@ -1878,10 +1880,10 @@ dependencies = [
 [[package]]
 name = "libdd-trace-normalization"
 version = "3.0.0"
-source = "git+https://github.com/DataDog/libdatadog?rev=63ecad56152f675fb74761d60adf5a861dafb1e1#63ecad56152f675fb74761d60adf5a861dafb1e1"
+source = "git+https://github.com/DataDog/libdatadog?rev=72fa86854c823361b7d234545f1a2f2d21f944fe#72fa86854c823361b7d234545f1a2f2d21f944fe"
 dependencies = [
  "anyhow",
- "libdd-trace-protobuf 4.0.0 (git+https://github.com/DataDog/libdatadog?rev=63ecad56152f675fb74761d60adf5a861dafb1e1)",
+ "libdd-trace-protobuf 4.0.0 (git+https://github.com/DataDog/libdatadog?rev=72fa86854c823361b7d234545f1a2f2d21f944fe)",
 ]
 
 [[package]]
@@ -1904,13 +1906,13 @@ dependencies = [
 [[package]]
 name = "libdd-trace-obfuscation"
 version = "5.0.0"
-source = "git+https://github.com/DataDog/libdatadog?rev=63ecad56152f675fb74761d60adf5a861dafb1e1#63ecad56152f675fb74761d60adf5a861dafb1e1"
+source = "git+https://github.com/DataDog/libdatadog?rev=72fa86854c823361b7d234545f1a2f2d21f944fe#72fa86854c823361b7d234545f1a2f2d21f944fe"
 dependencies = [
  "anyhow",
  "fluent-uri",
- "libdd-common 5.1.0 (git+https://github.com/DataDog/libdatadog?rev=63ecad56152f675fb74761d60adf5a861dafb1e1)",
- "libdd-trace-protobuf 4.0.0 (git+https://github.com/DataDog/libdatadog?rev=63ecad56152f675fb74761d60adf5a861dafb1e1)",
- "libdd-trace-utils 9.0.0 (git+https://github.com/DataDog/libdatadog?rev=63ecad56152f675fb74761d60adf5a861dafb1e1)",
+ "libdd-common 5.1.0 (git+https://github.com/DataDog/libdatadog?rev=72fa86854c823361b7d234545f1a2f2d21f944fe)",
+ "libdd-trace-protobuf 4.0.0 (git+https://github.com/DataDog/libdatadog?rev=72fa86854c823361b7d234545f1a2f2d21f944fe)",
+ "libdd-trace-utils 9.0.0 (git+https://github.com/DataDog/libdatadog?rev=72fa86854c823361b7d234545f1a2f2d21f944fe)",
  "log",
  "percent-encoding",
  "serde",
@@ -1931,7 +1933,7 @@ dependencies = [
 [[package]]
 name = "libdd-trace-protobuf"
 version = "4.0.0"
-source = "git+https://github.com/DataDog/libdatadog?rev=63ecad56152f675fb74761d60adf5a861dafb1e1#63ecad56152f675fb74761d60adf5a861dafb1e1"
+source = "git+https://github.com/DataDog/libdatadog?rev=72fa86854c823361b7d234545f1a2f2d21f944fe#72fa86854c823361b7d234545f1a2f2d21f944fe"
 dependencies = [
  "prost 0.14.3",
  "serde",
@@ -1969,7 +1971,7 @@ dependencies = [
 [[package]]
 name = "libdd-trace-stats"
 version = "6.0.0"
-source = "git+https://github.com/DataDog/libdatadog?rev=63ecad56152f675fb74761d60adf5a861dafb1e1#63ecad56152f675fb74761d60adf5a861dafb1e1"
+source = "git+https://github.com/DataDog/libdatadog?rev=72fa86854c823361b7d234545f1a2f2d21f944fe#72fa86854c823361b7d234545f1a2f2d21f944fe"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -1977,16 +1979,16 @@ dependencies = [
  "futures",
  "hashbrown 0.15.5",
  "http",
- "libdd-capabilities 2.1.0 (git+https://github.com/DataDog/libdatadog?rev=63ecad56152f675fb74761d60adf5a861dafb1e1)",
- "libdd-capabilities-impl 3.0.0 (git+https://github.com/DataDog/libdatadog?rev=63ecad56152f675fb74761d60adf5a861dafb1e1)",
- "libdd-common 5.1.0 (git+https://github.com/DataDog/libdatadog?rev=63ecad56152f675fb74761d60adf5a861dafb1e1)",
- "libdd-ddsketch 1.1.0 (git+https://github.com/DataDog/libdatadog?rev=63ecad56152f675fb74761d60adf5a861dafb1e1)",
- "libdd-dogstatsd-client 4.0.0 (git+https://github.com/DataDog/libdatadog?rev=63ecad56152f675fb74761d60adf5a861dafb1e1)",
- "libdd-shared-runtime 2.0.0 (git+https://github.com/DataDog/libdatadog?rev=63ecad56152f675fb74761d60adf5a861dafb1e1)",
- "libdd-telemetry 6.0.0 (git+https://github.com/DataDog/libdatadog?rev=63ecad56152f675fb74761d60adf5a861dafb1e1)",
- "libdd-trace-obfuscation 5.0.0 (git+https://github.com/DataDog/libdatadog?rev=63ecad56152f675fb74761d60adf5a861dafb1e1)",
- "libdd-trace-protobuf 4.0.0 (git+https://github.com/DataDog/libdatadog?rev=63ecad56152f675fb74761d60adf5a861dafb1e1)",
- "libdd-trace-utils 9.0.0 (git+https://github.com/DataDog/libdatadog?rev=63ecad56152f675fb74761d60adf5a861dafb1e1)",
+ "libdd-capabilities 2.1.0 (git+https://github.com/DataDog/libdatadog?rev=72fa86854c823361b7d234545f1a2f2d21f944fe)",
+ "libdd-capabilities-impl 3.0.0 (git+https://github.com/DataDog/libdatadog?rev=72fa86854c823361b7d234545f1a2f2d21f944fe)",
+ "libdd-common 5.1.0 (git+https://github.com/DataDog/libdatadog?rev=72fa86854c823361b7d234545f1a2f2d21f944fe)",
+ "libdd-ddsketch 1.1.0 (git+https://github.com/DataDog/libdatadog?rev=72fa86854c823361b7d234545f1a2f2d21f944fe)",
+ "libdd-dogstatsd-client 4.0.0 (git+https://github.com/DataDog/libdatadog?rev=72fa86854c823361b7d234545f1a2f2d21f944fe)",
+ "libdd-shared-runtime 2.0.0 (git+https://github.com/DataDog/libdatadog?rev=72fa86854c823361b7d234545f1a2f2d21f944fe)",
+ "libdd-telemetry 6.0.0 (git+https://github.com/DataDog/libdatadog?rev=72fa86854c823361b7d234545f1a2f2d21f944fe)",
+ "libdd-trace-obfuscation 5.0.0 (git+https://github.com/DataDog/libdatadog?rev=72fa86854c823361b7d234545f1a2f2d21f944fe)",
+ "libdd-trace-protobuf 4.0.0 (git+https://github.com/DataDog/libdatadog?rev=72fa86854c823361b7d234545f1a2f2d21f944fe)",
+ "libdd-trace-utils 9.0.0 (git+https://github.com/DataDog/libdatadog?rev=72fa86854c823361b7d234545f1a2f2d21f944fe)",
  "rmp-serde",
  "serde",
  "tokio",
@@ -2034,7 +2036,7 @@ dependencies = [
 [[package]]
 name = "libdd-trace-utils"
 version = "9.0.0"
-source = "git+https://github.com/DataDog/libdatadog?rev=63ecad56152f675fb74761d60adf5a861dafb1e1#63ecad56152f675fb74761d60adf5a861dafb1e1"
+source = "git+https://github.com/DataDog/libdatadog?rev=72fa86854c823361b7d234545f1a2f2d21f944fe#72fa86854c823361b7d234545f1a2f2d21f944fe"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -2052,12 +2054,12 @@ dependencies = [
  "hyper",
  "indexmap",
  "itoa",
- "libdd-capabilities 2.1.0 (git+https://github.com/DataDog/libdatadog?rev=63ecad56152f675fb74761d60adf5a861dafb1e1)",
- "libdd-capabilities-impl 3.0.0 (git+https://github.com/DataDog/libdatadog?rev=63ecad56152f675fb74761d60adf5a861dafb1e1)",
- "libdd-common 5.1.0 (git+https://github.com/DataDog/libdatadog?rev=63ecad56152f675fb74761d60adf5a861dafb1e1)",
- "libdd-tinybytes 1.1.1 (git+https://github.com/DataDog/libdatadog?rev=63ecad56152f675fb74761d60adf5a861dafb1e1)",
- "libdd-trace-normalization 3.0.0 (git+https://github.com/DataDog/libdatadog?rev=63ecad56152f675fb74761d60adf5a861dafb1e1)",
- "libdd-trace-protobuf 4.0.0 (git+https://github.com/DataDog/libdatadog?rev=63ecad56152f675fb74761d60adf5a861dafb1e1)",
+ "libdd-capabilities 2.1.0 (git+https://github.com/DataDog/libdatadog?rev=72fa86854c823361b7d234545f1a2f2d21f944fe)",
+ "libdd-capabilities-impl 3.0.0 (git+https://github.com/DataDog/libdatadog?rev=72fa86854c823361b7d234545f1a2f2d21f944fe)",
+ "libdd-common 5.1.0 (git+https://github.com/DataDog/libdatadog?rev=72fa86854c823361b7d234545f1a2f2d21f944fe)",
+ "libdd-tinybytes 1.1.1 (git+https://github.com/DataDog/libdatadog?rev=72fa86854c823361b7d234545f1a2f2d21f944fe)",
+ "libdd-trace-normalization 3.0.0 (git+https://github.com/DataDog/libdatadog?rev=72fa86854c823361b7d234545f1a2f2d21f944fe)",
+ "libdd-trace-protobuf 4.0.0 (git+https://github.com/DataDog/libdatadog?rev=72fa86854c823361b7d234545f1a2f2d21f944fe)",
  "prost 0.14.3",
  "rand 0.8.6",
  "rmp",

--- a/crates/datadog-agent-config/Cargo.toml
+++ b/crates/datadog-agent-config/Cargo.toml
@@ -6,8 +6,8 @@ license.workspace = true
 
 [dependencies]
 figment = { version = "0.10", default-features = false, features = ["yaml", "env"] }
-libdd-trace-obfuscation = { git = "https://github.com/DataDog/libdatadog", rev = "85ce322a1dcb1eda7df9bcc021223b2d1a236783", default-features = false }
-libdd-trace-utils = { git = "https://github.com/DataDog/libdatadog", rev = "85ce322a1dcb1eda7df9bcc021223b2d1a236783", default-features = false }
+libdd-trace-obfuscation = { git = "https://github.com/DataDog/libdatadog", rev = "63ecad56152f675fb74761d60adf5a861dafb1e1", default-features = false }
+libdd-trace-utils = { git = "https://github.com/DataDog/libdatadog", rev = "63ecad56152f675fb74761d60adf5a861dafb1e1", default-features = false }
 log = { version = "0.4", default-features = false }
 serde = { version = "1.0", default-features = false, features = ["derive"] }
 serde-aux = { version = "4.7", default-features = false }

--- a/crates/datadog-agent-config/Cargo.toml
+++ b/crates/datadog-agent-config/Cargo.toml
@@ -6,8 +6,8 @@ license.workspace = true
 
 [dependencies]
 figment = { version = "0.10", default-features = false, features = ["yaml", "env"] }
-libdd-trace-obfuscation = { git = "https://github.com/DataDog/libdatadog", rev = "63ecad56152f675fb74761d60adf5a861dafb1e1", default-features = false }
-libdd-trace-utils = { git = "https://github.com/DataDog/libdatadog", rev = "63ecad56152f675fb74761d60adf5a861dafb1e1", default-features = false }
+libdd-trace-obfuscation = { git = "https://github.com/DataDog/libdatadog", rev = "72fa86854c823361b7d234545f1a2f2d21f944fe", default-features = false }
+libdd-trace-utils = { git = "https://github.com/DataDog/libdatadog", rev = "72fa86854c823361b7d234545f1a2f2d21f944fe", default-features = false }
 log = { version = "0.4", default-features = false }
 serde = { version = "1.0", default-features = false, features = ["derive"] }
 serde-aux = { version = "4.7", default-features = false }

--- a/crates/datadog-metrics-collector/Cargo.toml
+++ b/crates/datadog-metrics-collector/Cargo.toml
@@ -8,7 +8,7 @@ description = "Collector to read, compute, and submit enhanced metrics in Server
 [dependencies]
 dogstatsd = { path = "../dogstatsd", default-features = true }
 tracing = { version = "0.1", default-features = false }
-libdd-common = { git = "https://github.com/DataDog/libdatadog", rev = "a820699426f28cbabb3a74d87c7309d030b52e7c", default-features = false }
+libdd-common = { git = "https://github.com/DataDog/libdatadog", rev = "63ecad56152f675fb74761d60adf5a861dafb1e1", default-features = false }
 
 [target.'cfg(windows)'.dependencies]
 windows-sys = { version = "0.61", features = ["Win32_System_JobObjects"], optional = true, default-features = false }

--- a/crates/datadog-metrics-collector/Cargo.toml
+++ b/crates/datadog-metrics-collector/Cargo.toml
@@ -8,7 +8,7 @@ description = "Collector to read, compute, and submit enhanced metrics in Server
 [dependencies]
 dogstatsd = { path = "../dogstatsd", default-features = true }
 tracing = { version = "0.1", default-features = false }
-libdd-common = { git = "https://github.com/DataDog/libdatadog", rev = "63ecad56152f675fb74761d60adf5a861dafb1e1", default-features = false }
+libdd-common = { git = "https://github.com/DataDog/libdatadog", rev = "72fa86854c823361b7d234545f1a2f2d21f944fe", default-features = false }
 
 [target.'cfg(windows)'.dependencies]
 windows-sys = { version = "0.61", features = ["Win32_System_JobObjects"], optional = true, default-features = false }

--- a/crates/datadog-serverless-compat/Cargo.toml
+++ b/crates/datadog-serverless-compat/Cargo.toml
@@ -14,7 +14,7 @@ windows-enhanced-metrics = ["datadog-metrics-collector/windows-enhanced-metrics"
 datadog-logs-agent = { path = "../datadog-logs-agent" }
 datadog-metrics-collector = { path = "../datadog-metrics-collector" }
 datadog-trace-agent = { path = "../datadog-trace-agent" }
-libdd-trace-utils = { git = "https://github.com/DataDog/libdatadog", rev = "a820699426f28cbabb3a74d87c7309d030b52e7c" }
+libdd-trace-utils = { git = "https://github.com/DataDog/libdatadog", rev = "63ecad56152f675fb74761d60adf5a861dafb1e1" }
 datadog-fips = { path = "../datadog-fips", default-features = false }
 dogstatsd = { path = "../dogstatsd", default-features = true }
 reqwest = { version = "0.12.4", default-features = false }

--- a/crates/datadog-serverless-compat/Cargo.toml
+++ b/crates/datadog-serverless-compat/Cargo.toml
@@ -14,7 +14,7 @@ windows-enhanced-metrics = ["datadog-metrics-collector/windows-enhanced-metrics"
 datadog-logs-agent = { path = "../datadog-logs-agent" }
 datadog-metrics-collector = { path = "../datadog-metrics-collector" }
 datadog-trace-agent = { path = "../datadog-trace-agent" }
-libdd-trace-utils = { git = "https://github.com/DataDog/libdatadog", rev = "63ecad56152f675fb74761d60adf5a861dafb1e1" }
+libdd-trace-utils = { git = "https://github.com/DataDog/libdatadog", rev = "72fa86854c823361b7d234545f1a2f2d21f944fe" }
 datadog-fips = { path = "../datadog-fips", default-features = false }
 dogstatsd = { path = "../dogstatsd", default-features = true }
 reqwest = { version = "0.12.4", default-features = false }

--- a/crates/datadog-trace-agent/Cargo.toml
+++ b/crates/datadog-trace-agent/Cargo.toml
@@ -25,16 +25,16 @@ tracing = { version = "0.1", default-features = false }
 serde = { version = "1.0.145", features = ["derive"] }
 serde_json = "1.0"
 thiserror = { version = "1.0.58", default-features = false }
-libdd-capabilities = { git = "https://github.com/DataDog/libdatadog", rev = "a820699426f28cbabb3a74d87c7309d030b52e7c" }
-libdd-capabilities-impl = { git = "https://github.com/DataDog/libdatadog", rev = "a820699426f28cbabb3a74d87c7309d030b52e7c" }
-libdd-common = { git = "https://github.com/DataDog/libdatadog", rev = "a820699426f28cbabb3a74d87c7309d030b52e7c" }
-libdd-library-config = { git = "https://github.com/DataDog/libdatadog", rev = "a820699426f28cbabb3a74d87c7309d030b52e7c" }
-libdd-trace-protobuf = { git = "https://github.com/DataDog/libdatadog", rev = "a820699426f28cbabb3a74d87c7309d030b52e7c" }
-libdd-trace-stats = { git = "https://github.com/DataDog/libdatadog", rev = "a820699426f28cbabb3a74d87c7309d030b52e7c" }
-libdd-trace-utils = { git = "https://github.com/DataDog/libdatadog", rev = "a820699426f28cbabb3a74d87c7309d030b52e7c", features = [
+libdd-capabilities = { git = "https://github.com/DataDog/libdatadog", rev = "63ecad56152f675fb74761d60adf5a861dafb1e1" }
+libdd-capabilities-impl = { git = "https://github.com/DataDog/libdatadog", rev = "63ecad56152f675fb74761d60adf5a861dafb1e1" }
+libdd-common = { git = "https://github.com/DataDog/libdatadog", rev = "63ecad56152f675fb74761d60adf5a861dafb1e1" }
+libdd-library-config = { git = "https://github.com/DataDog/libdatadog", rev = "63ecad56152f675fb74761d60adf5a861dafb1e1" }
+libdd-trace-protobuf = { git = "https://github.com/DataDog/libdatadog", rev = "63ecad56152f675fb74761d60adf5a861dafb1e1" }
+libdd-trace-stats = { git = "https://github.com/DataDog/libdatadog", rev = "63ecad56152f675fb74761d60adf5a861dafb1e1" }
+libdd-trace-utils = { git = "https://github.com/DataDog/libdatadog", rev = "63ecad56152f675fb74761d60adf5a861dafb1e1", features = [
     "mini_agent",
 ] }
-libdd-trace-obfuscation = { git = "https://github.com/DataDog/libdatadog", rev = "a820699426f28cbabb3a74d87c7309d030b52e7c" }
+libdd-trace-obfuscation = { git = "https://github.com/DataDog/libdatadog", rev = "63ecad56152f675fb74761d60adf5a861dafb1e1" }
 datadog-fips = { path = "../datadog-fips" }
 reqwest = { version = "0.12.23", features = [
     "json",
@@ -49,6 +49,6 @@ serial_test = "2.0.0"
 duplicate = "2.0.1"
 temp-env = "0.3.6"
 tempfile = "3.3.0"
-libdd-trace-utils = { git = "https://github.com/DataDog/libdatadog", rev = "a820699426f28cbabb3a74d87c7309d030b52e7c", features = [
+libdd-trace-utils = { git = "https://github.com/DataDog/libdatadog", rev = "63ecad56152f675fb74761d60adf5a861dafb1e1", features = [
     "test-utils",
 ] }

--- a/crates/datadog-trace-agent/Cargo.toml
+++ b/crates/datadog-trace-agent/Cargo.toml
@@ -25,16 +25,16 @@ tracing = { version = "0.1", default-features = false }
 serde = { version = "1.0.145", features = ["derive"] }
 serde_json = "1.0"
 thiserror = { version = "1.0.58", default-features = false }
-libdd-capabilities = { git = "https://github.com/DataDog/libdatadog", rev = "63ecad56152f675fb74761d60adf5a861dafb1e1" }
-libdd-capabilities-impl = { git = "https://github.com/DataDog/libdatadog", rev = "63ecad56152f675fb74761d60adf5a861dafb1e1" }
-libdd-common = { git = "https://github.com/DataDog/libdatadog", rev = "63ecad56152f675fb74761d60adf5a861dafb1e1" }
-libdd-library-config = { git = "https://github.com/DataDog/libdatadog", rev = "63ecad56152f675fb74761d60adf5a861dafb1e1" }
-libdd-trace-protobuf = { git = "https://github.com/DataDog/libdatadog", rev = "63ecad56152f675fb74761d60adf5a861dafb1e1" }
-libdd-trace-stats = { git = "https://github.com/DataDog/libdatadog", rev = "63ecad56152f675fb74761d60adf5a861dafb1e1" }
-libdd-trace-utils = { git = "https://github.com/DataDog/libdatadog", rev = "63ecad56152f675fb74761d60adf5a861dafb1e1", features = [
+libdd-capabilities = { git = "https://github.com/DataDog/libdatadog", rev = "72fa86854c823361b7d234545f1a2f2d21f944fe" }
+libdd-capabilities-impl = { git = "https://github.com/DataDog/libdatadog", rev = "72fa86854c823361b7d234545f1a2f2d21f944fe" }
+libdd-common = { git = "https://github.com/DataDog/libdatadog", rev = "72fa86854c823361b7d234545f1a2f2d21f944fe" }
+libdd-library-config = { git = "https://github.com/DataDog/libdatadog", rev = "72fa86854c823361b7d234545f1a2f2d21f944fe" }
+libdd-trace-protobuf = { git = "https://github.com/DataDog/libdatadog", rev = "72fa86854c823361b7d234545f1a2f2d21f944fe" }
+libdd-trace-stats = { git = "https://github.com/DataDog/libdatadog", rev = "72fa86854c823361b7d234545f1a2f2d21f944fe" }
+libdd-trace-utils = { git = "https://github.com/DataDog/libdatadog", rev = "72fa86854c823361b7d234545f1a2f2d21f944fe", features = [
     "mini_agent",
 ] }
-libdd-trace-obfuscation = { git = "https://github.com/DataDog/libdatadog", rev = "63ecad56152f675fb74761d60adf5a861dafb1e1" }
+libdd-trace-obfuscation = { git = "https://github.com/DataDog/libdatadog", rev = "72fa86854c823361b7d234545f1a2f2d21f944fe" }
 datadog-fips = { path = "../datadog-fips" }
 reqwest = { version = "0.12.23", features = [
     "json",
@@ -49,6 +49,6 @@ serial_test = "2.0.0"
 duplicate = "2.0.1"
 temp-env = "0.3.6"
 tempfile = "3.3.0"
-libdd-trace-utils = { git = "https://github.com/DataDog/libdatadog", rev = "63ecad56152f675fb74761d60adf5a861dafb1e1", features = [
+libdd-trace-utils = { git = "https://github.com/DataDog/libdatadog", rev = "72fa86854c823361b7d234545f1a2f2d21f944fe", features = [
     "test-utils",
 ] }

--- a/crates/datadog-trace-agent/src/aggregator.rs
+++ b/crates/datadog-trace-agent/src/aggregator.rs
@@ -71,7 +71,8 @@ impl TraceAggregator {
 mod tests {
     use libdd_common::Endpoint;
     use libdd_trace_utils::{
-        trace_utils::TracerHeaderTags, tracer_payload::TracerPayloadCollection,
+        trace_utils::{TracerGenericTags, TracerHeaderTags},
+        tracer_payload::TracerPayloadCollection,
     };
 
     use super::*;
@@ -84,10 +85,12 @@ mod tests {
             lang_vendor: "lang_vendor",
             tracer_version: "tracer_version",
             container_id: "container_id",
-            client_computed_top_level: true,
-            client_computed_stats: true,
-            dropped_p0_traces: 0,
-            dropped_p0_spans: 0,
+            generic: TracerGenericTags {
+                client_computed_top_level: true,
+                client_computed_stats: true,
+                dropped_p0_traces: 0,
+                dropped_p0_spans: 0,
+            },
         };
         SendData::new(
             size,

--- a/crates/datadog-trace-agent/src/config.rs
+++ b/crates/datadog-trace-agent/src/config.rs
@@ -115,6 +115,11 @@ pub struct Config {
     pub proxy_url: Option<String>,
     pub env: String,
     pub peer_tags: Vec<String>,
+    /// Gates additional_metric_tags and related config.
+    pub experimental_features_enabled: bool,
+    /// Tag keys extracted from spans and used as additional aggregation dimensions in stats.
+    /// Only populated when experimental_features_enabled is true.
+    pub additional_metric_tags: Vec<String>,
     /// Whether the agent should compute trace stats
     pub agent_stats_computation_enabled: bool,
 }
@@ -216,6 +221,10 @@ impl Config {
             Tags::new()
         };
 
+        let experimental_features_enabled = env::var("DD_TRACE_EXPERIMENTAL_FEATURES_ENABLED")
+            .map(|val| val.to_lowercase() == "true")
+            .unwrap_or(false);
+
         #[allow(clippy::unwrap_used)]
         Ok(Config {
             app_name: Some(app_name),
@@ -262,6 +271,22 @@ impl Config {
             tags,
             env: env::var("DD_ENV").unwrap_or_else(|_| "none".to_string()),
             peer_tags: peer_tag_keys()?,
+            experimental_features_enabled,
+            additional_metric_tags: if experimental_features_enabled {
+                env::var("DD_TRACE_STATS_ADDITIONAL_TAGS")
+                    .ok()
+                    .filter(|s| !s.is_empty())
+                    .map(|s| {
+                        s.split(',')
+                            .map(str::trim)
+                            .filter(|s| !s.is_empty())
+                            .map(str::to_owned)
+                            .collect()
+                    })
+                    .unwrap_or_default()
+            } else {
+                vec![]
+            },
             agent_stats_computation_enabled: env::var("DD_AGENT_STATS_COMPUTATION_ENABLED")
                 .map(|val| val.to_lowercase() == "true")
                 .unwrap_or(false),
@@ -745,6 +770,47 @@ mod tests {
             },
         );
     }
+
+    #[test]
+    #[serial]
+    fn test_additional_metric_tags_gated_by_experimental_flag() {
+        let base_vars = [
+            ("DD_API_KEY", Some("_not_a_real_key_")),
+            ("FUNCTIONS_EXTENSION_VERSION", Some("~4")),
+            ("FUNCTIONS_WORKER_RUNTIME", Some("dotnet")),
+            ("WEBSITE_SITE_NAME", Some("my-azure-function")),
+            ("DD_TRACE_STATS_ADDITIONAL_TAGS", Some("region,tenant_id")),
+        ];
+
+        temp_env::with_vars(
+            base_vars
+                .iter()
+                .cloned()
+                .chain([("DD_TRACE_EXPERIMENTAL_FEATURES_ENABLED", Some("false"))])
+                .collect::<Vec<_>>(),
+            || {
+                let config = config::Config::new().unwrap();
+                assert!(!config.experimental_features_enabled);
+                assert!(config.additional_metric_tags.is_empty());
+            },
+        );
+
+        temp_env::with_vars(
+            base_vars
+                .iter()
+                .cloned()
+                .chain([("DD_TRACE_EXPERIMENTAL_FEATURES_ENABLED", Some("true"))])
+                .collect::<Vec<_>>(),
+            || {
+                let config = config::Config::new().unwrap();
+                assert!(config.experimental_features_enabled);
+                assert_eq!(
+                    config.additional_metric_tags,
+                    vec!["region".to_string(), "tenant_id".to_string()]
+                );
+            },
+        );
+    }
 }
 
 /// Test helpers for creating Config instances in tests
@@ -782,6 +848,8 @@ pub mod test_helpers {
             proxy_url: None,
             env: "none".to_string(),
             peer_tags: peer_tag_keys().unwrap(),
+            experimental_features_enabled: false,
+            additional_metric_tags: vec![],
             agent_stats_computation_enabled: false,
         }
     }

--- a/crates/datadog-trace-agent/src/config.rs
+++ b/crates/datadog-trace-agent/src/config.rs
@@ -120,8 +120,9 @@ pub struct Config {
     /// Tag keys extracted from spans and used as additional aggregation dimensions in stats.
     /// Only populated when experimental_features_enabled is true.
     pub additional_metric_tags: Vec<String>,
-    /// Per-field cardinality limit for the additional metric tags dimension.
+    /// Per field cardinality limit for the additional metric tags dimension.
     /// `None` means use the default configured in libdatadog.
+    /// Only populated when experimental_features_enabled is true.
     pub additional_metric_tags_cardinality_limit: Option<usize>,
     /// Whether the agent should compute trace stats
     pub agent_stats_computation_enabled: bool,

--- a/crates/datadog-trace-agent/src/config.rs
+++ b/crates/datadog-trace-agent/src/config.rs
@@ -120,6 +120,9 @@ pub struct Config {
     /// Tag keys extracted from spans and used as additional aggregation dimensions in stats.
     /// Only populated when experimental_features_enabled is true.
     pub additional_metric_tags: Vec<String>,
+    /// Per-field cardinality limit for the additional metric tags dimension.
+    /// `None` means use the default configured in libdatadog.
+    pub additional_metric_tags_cardinality_limit: Option<usize>,
     /// Whether the agent should compute trace stats
     pub agent_stats_computation_enabled: bool,
 }
@@ -286,6 +289,13 @@ impl Config {
                     .unwrap_or_default()
             } else {
                 vec![]
+            },
+            additional_metric_tags_cardinality_limit: if experimental_features_enabled {
+                env::var("DD_TRACE_STATS_ADDITIONAL_TAGS_CARDINALITY_LIMIT")
+                    .ok()
+                    .and_then(|s| s.parse::<usize>().ok())
+            } else {
+                None
             },
             agent_stats_computation_enabled: env::var("DD_AGENT_STATS_COMPUTATION_ENABLED")
                 .map(|val| val.to_lowercase() == "true")
@@ -811,6 +821,69 @@ mod tests {
             },
         );
     }
+
+    #[test]
+    #[serial]
+    fn test_additional_metric_tags_cardinality_limit_gated_by_experimental_flag() {
+        let base_vars = [
+            ("DD_API_KEY", Some("_not_a_real_key_")),
+            ("FUNCTIONS_EXTENSION_VERSION", Some("~4")),
+            ("FUNCTIONS_WORKER_RUNTIME", Some("dotnet")),
+            ("WEBSITE_SITE_NAME", Some("my-azure-function")),
+            (
+                "DD_TRACE_STATS_ADDITIONAL_TAGS_CARDINALITY_LIMIT",
+                Some("50"),
+            ),
+        ];
+
+        temp_env::with_vars(
+            base_vars
+                .iter()
+                .cloned()
+                .chain([("DD_TRACE_EXPERIMENTAL_FEATURES_ENABLED", Some("false"))])
+                .collect::<Vec<_>>(),
+            || {
+                let config = config::Config::new().unwrap();
+                assert!(!config.experimental_features_enabled);
+                assert_eq!(config.additional_metric_tags_cardinality_limit, None);
+            },
+        );
+
+        temp_env::with_vars(
+            base_vars
+                .iter()
+                .cloned()
+                .chain([("DD_TRACE_EXPERIMENTAL_FEATURES_ENABLED", Some("true"))])
+                .collect::<Vec<_>>(),
+            || {
+                let config = config::Config::new().unwrap();
+                assert!(config.experimental_features_enabled);
+                assert_eq!(config.additional_metric_tags_cardinality_limit, Some(50));
+            },
+        );
+    }
+
+    #[test]
+    #[serial]
+    fn test_additional_metric_tags_cardinality_limit_invalid_value() {
+        temp_env::with_vars(
+            [
+                ("DD_API_KEY", Some("_not_a_real_key_")),
+                ("FUNCTIONS_EXTENSION_VERSION", Some("~4")),
+                ("FUNCTIONS_WORKER_RUNTIME", Some("dotnet")),
+                ("WEBSITE_SITE_NAME", Some("my-azure-function")),
+                ("DD_TRACE_EXPERIMENTAL_FEATURES_ENABLED", Some("true")),
+                (
+                    "DD_TRACE_STATS_ADDITIONAL_TAGS_CARDINALITY_LIMIT",
+                    Some("not_a_number"),
+                ),
+            ],
+            || {
+                let config = config::Config::new().unwrap();
+                assert_eq!(config.additional_metric_tags_cardinality_limit, None);
+            },
+        );
+    }
 }
 
 /// Test helpers for creating Config instances in tests
@@ -850,6 +923,7 @@ pub mod test_helpers {
             peer_tags: peer_tag_keys().unwrap(),
             experimental_features_enabled: false,
             additional_metric_tags: vec![],
+            additional_metric_tags_cardinality_limit: None,
             agent_stats_computation_enabled: false,
         }
     }

--- a/crates/datadog-trace-agent/src/stats_concentrator_service.rs
+++ b/crates/datadog-trace-agent/src/stats_concentrator_service.rs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use std::collections::HashMap;
+use std::hash::{Hash, Hasher};
 use std::sync::Arc;
 use tokio::sync::{mpsc, oneshot};
 
@@ -61,9 +62,39 @@ impl StatsConcentratorHandle {
     }
 }
 
+/// Wraps `Arc<TracerMetadata>` so it can be used as a `HashMap` key. `TracerMetadata` only derives
+/// `PartialEq` upstream in libdatadog, not `Eq` or `Hash`. All fields are `Eq` + `Hash`,
+/// so hashing them field by field is consistent with equality.
+#[derive(Debug, Clone)]
+struct MetadataKey(Arc<TracerMetadata>);
+
+impl PartialEq for MetadataKey {
+    fn eq(&self, other: &Self) -> bool {
+        self.0 == other.0
+    }
+}
+
+impl Eq for MetadataKey {}
+
+impl Hash for MetadataKey {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        let metadata = &*self.0;
+        metadata.schema_version.hash(state);
+        metadata.runtime_id.hash(state);
+        metadata.tracer_language.hash(state);
+        metadata.tracer_version.hash(state);
+        metadata.hostname.hash(state);
+        metadata.service_name.hash(state);
+        metadata.service_env.hash(state);
+        metadata.service_version.hash(state);
+        metadata.process_tags.hash(state);
+        metadata.container_id.hash(state);
+    }
+}
+
 pub struct StatsConcentratorService {
     /// One concentrator per unique TracerMetadata.
-    concentrators: HashMap<Arc<TracerMetadata>, SpanConcentrator>,
+    concentrators: HashMap<MetadataKey, SpanConcentrator>,
     rx: mpsc::UnboundedReceiver<ConcentratorCommand>,
     config: Arc<Config>,
 }
@@ -81,7 +112,10 @@ impl StatsConcentratorService {
         (service, handle)
     }
 
-    fn new_span_concentrator(peer_tags: Vec<String>) -> SpanConcentrator {
+    fn new_span_concentrator(
+        peer_tags: Vec<String>,
+        additional_metric_tags: Vec<String>,
+    ) -> SpanConcentrator {
         SpanConcentrator::new(
             Duration::from_nanos(BUCKET_DURATION_NS),
             SystemTime::now(),
@@ -90,6 +124,8 @@ impl StatsConcentratorService {
                 .map(|s| s.to_string())
                 .collect(),
             peer_tags,
+            None,
+            additional_metric_tags,
         )
     }
 
@@ -105,8 +141,13 @@ impl StatsConcentratorService {
                     let config = Arc::clone(&self.config);
                     let concentrator = self
                         .concentrators
-                        .entry(Arc::clone(&metadata))
-                        .or_insert_with(|| Self::new_span_concentrator(config.peer_tags.clone()));
+                        .entry(MetadataKey(Arc::clone(&metadata)))
+                        .or_insert_with(|| {
+                            Self::new_span_concentrator(
+                                config.peer_tags.clone(),
+                                config.additional_metric_tags.clone(),
+                            )
+                        });
 
                     for span in &chunk.spans {
                         concentrator.add_span(span);
@@ -127,8 +168,10 @@ impl StatsConcentratorService {
         let payloads = self
             .concentrators
             .iter_mut()
-            .filter_map(|(metadata, concentrator)| {
-                let stats_buckets = concentrator.flush(SystemTime::now(), force_flush);
+            .filter_map(|(key, concentrator)| {
+                let metadata = &key.0;
+                let flush_result = concentrator.flush(SystemTime::now(), force_flush);
+                let stats_buckets = flush_result.unobfuscated_buckets;
                 if stats_buckets.is_empty() {
                     return None;
                 }

--- a/crates/datadog-trace-agent/src/stats_concentrator_service.rs
+++ b/crates/datadog-trace-agent/src/stats_concentrator_service.rs
@@ -9,7 +9,7 @@ use tokio::sync::{mpsc, oneshot};
 use crate::config::Config;
 use libdd_library_config::tracer_metadata::TracerMetadata;
 use libdd_trace_protobuf::pb::{ClientStatsPayload, TraceChunk};
-use libdd_trace_stats::span_concentrator::SpanConcentrator;
+use libdd_trace_stats::span_concentrator::{CardinalityLimitConfig, SpanConcentrator};
 use std::time::{Duration, SystemTime};
 use tracing::error;
 
@@ -115,7 +115,15 @@ impl StatsConcentratorService {
     fn new_span_concentrator(
         peer_tags: Vec<String>,
         additional_metric_tags: Vec<String>,
+        additional_metric_tags_cardinality_limit: Option<usize>,
     ) -> SpanConcentrator {
+        let override_cardinality_limits =
+            additional_metric_tags_cardinality_limit.map(|additional_tags_limit| {
+                CardinalityLimitConfig {
+                    additional_tags_limit,
+                    ..Default::default()
+                }
+            });
         SpanConcentrator::new(
             Duration::from_nanos(BUCKET_DURATION_NS),
             SystemTime::now(),
@@ -124,7 +132,7 @@ impl StatsConcentratorService {
                 .map(|s| s.to_string())
                 .collect(),
             peer_tags,
-            None,
+            override_cardinality_limits,
             additional_metric_tags,
         )
     }
@@ -146,6 +154,7 @@ impl StatsConcentratorService {
                             Self::new_span_concentrator(
                                 config.peer_tags.clone(),
                                 config.additional_metric_tags.clone(),
+                                config.additional_metric_tags_cardinality_limit,
                             )
                         });
 

--- a/crates/datadog-trace-agent/src/trace_processor.rs
+++ b/crates/datadog-trace-agent/src/trace_processor.rs
@@ -109,6 +109,7 @@ impl ServerlessTraceProcessor {
                 TracerPayloadCollection::V04(_) => "V04",
                 TracerPayloadCollection::V05(_) => "V05",
                 TracerPayloadCollection::V07(_) => unreachable!(),
+                TracerPayloadCollection::V1(_) => "V1",
             };
             error!("Unsupported tracer payload version {version}. Failed to send trace stats.");
         }
@@ -285,6 +286,8 @@ mod tests {
             tags: Tags::from_env_string("env:test,service:my-service"),
             env: "test-env".to_string(),
             peer_tags: peer_tag_keys().unwrap(),
+            experimental_features_enabled: false,
+            additional_metric_tags: vec![],
             agent_stats_computation_enabled: false,
         }
     }
@@ -358,6 +361,7 @@ mod tests {
             env: "test-env".to_string(),
             hostname: "".to_string(),
             app_version: "".to_string(),
+            container_debug: None,
         };
 
         let received_payload =
@@ -436,6 +440,7 @@ mod tests {
             env: "test-env".to_string(),
             hostname: "".to_string(),
             app_version: "".to_string(),
+            container_debug: None,
         };
 
         let received_payload =

--- a/crates/datadog-trace-agent/src/trace_processor.rs
+++ b/crates/datadog-trace-agent/src/trace_processor.rs
@@ -191,7 +191,7 @@ impl TraceProcessor for ServerlessTraceProcessor {
         // Skip agent side stats computation if disabled or if the tracer has already computed stats
         if let Some(ref concentrator) = self.stats_concentrator
             && config.agent_stats_computation_enabled
-            && !tracer_header_tags.client_computed_stats
+            && !tracer_header_tags.generic.client_computed_stats
         {
             Self::send_to_concentrator(concentrator, &payload);
         }

--- a/crates/datadog-trace-agent/src/trace_processor.rs
+++ b/crates/datadog-trace-agent/src/trace_processor.rs
@@ -288,6 +288,7 @@ mod tests {
             peer_tags: peer_tag_keys().unwrap(),
             experimental_features_enabled: false,
             additional_metric_tags: vec![],
+            additional_metric_tags_cardinality_limit: None,
             agent_stats_computation_enabled: false,
         }
     }


### PR DESCRIPTION
### What does this PR do?

- Add `DD_TRACE_STATS_ADDITIONAL_TAGS` setting for adding additional tags to trace stats.
- Add `DD_TRACE_STATS_ADDITIONAL_TAGS_CARDINALITY_LIMIT` to limit number of distinct stats entries (default of 100 in `libdd-trace-stats` if no value is passed).
- Add `DD_TRACE_EXPERIMENTAL_FEATURES_ENABLED` to gate the behavior behind `DD_TRACE_STATS_ADDITIONAL_TAGS` and `DD_TRACE_STATS_ADDITIONAL_TAGS_CARDINALITY_LIMIT`.

### Motivation

Allow Serverless Compatibility Layer to send additional metric tags on trace stats. See [RFC](https://datadoghq.atlassian.net/wiki/spaces/APM/pages/6482919540/PENDING+Span-Derived+Primary+Tags+-+V1).

https://datadoghq.atlassian.net/browse/SVLS-8787

### Additional Notes

Dependent on these changes in libdatadog: https://github.com/DataDog/libdatadog/pull/2170

### Describe how to test/QA your changes

- Unit tests for regressions and new functionality added by `DD_TRACE_EXPERIMENTAL_FEATURES_ENABLED`
- Deploy to Azure Functions with the following environment variables and validate that additional tags appear on trace metrics
  * `DD_TAGS: custom.primary:val,workload:azure_functions`
  * `DD_TRACE_EXPERIMENTAL_FEATURES_ENABLED: true`
  * `DD_TRACE_STATS_ADDITIONAL_TAGS: custom.primary,workload`

<img width="685" height="411" alt="Screenshot 2026-07-06 at 3 39 47 PM" src="https://github.com/user-attachments/assets/b91495b6-11aa-4051-922f-63655666c4e5" />

