### PR TITLE
fix: add the dogstatsd url validator call in dd url tests

### DIFF
--- a/crates/datadog-agent-config/src/lib.rs
+++ b/crates/datadog-agent-config/src/lib.rs
@@ -789,6 +789,8 @@ pub mod tests {
                 config.dd_url,
                 "https://test.agent.datadoghq.com".to_string()
             );
+            dogstatsd::datadog::DdDdUrl::new(config.dd_url.clone())
+                .expect("DD_DD_URL with a trailing slash should still parse");
             Ok(())
         });
     }
@@ -813,6 +815,8 @@ pub mod tests {
 
             let config = get_config(Path::new(""));
             assert_eq!(config.url, "https://test.datadoghq.com".to_string());
+            dogstatsd::datadog::DdUrl::new(config.url.clone())
+                .expect("DD_URL with a trailing slash should still parse");
             Ok(())
         });
     }


### PR DESCRIPTION
Follow-up to #142, which trimmed trailing slashes from dd_url/url because dogstatsd's DdUrl/DdDdUrl reject a trailing slash with UrlPrefixError. The tests asserted that the trimmed string matched the expected value. This adds dogstatsd::datadog::DdDdUrl::new(...)/DdUrl::new(...) calls to the earlier unit tests, so the tests fail if trim_url ever regresses in a way that still gets rejected by the prefix validator, instead of only checking the trim behavior.
