### PR TITLE
feat: enable agent stats computation by default

### DIFF
--- a/crates/datadog-serverless-compat/src/main.rs
+++ b/crates/datadog-serverless-compat/src/main.rs
@@ -138,10 +138,6 @@ pub async fn main() {
 
     let instance_metric_enabled = env_type == EnvironmentType::AzureFunction;
 
-    let dd_agent_stats_computation_enabled = env::var("DD_AGENT_STATS_COMPUTATION_ENABLED")
-        .map(|val| val.to_lowercase() == "true")
-        .unwrap_or(false);
-
     debug!("Starting serverless trace mini agent");
 
     let env_filter = format!("h2=off,hyper=off,rustls=off,{}", log_level);
@@ -175,7 +171,7 @@ pub async fn main() {
         }
     };
 
-    let stats_concentrator = if dd_agent_stats_computation_enabled {
+    let stats_concentrator = if config.agent_stats_computation_enabled {
         info!("agent stats computation enabled");
         let (service, handle) =
             stats_concentrator_service::StatsConcentratorService::new(config.clone());

--- a/crates/datadog-trace-agent/src/config.rs
+++ b/crates/datadog-trace-agent/src/config.rs
@@ -300,7 +300,7 @@ impl Config {
             },
             agent_stats_computation_enabled: env::var("DD_AGENT_STATS_COMPUTATION_ENABLED")
                 .map(|val| val.to_lowercase() == "true")
-                .unwrap_or(false),
+                .unwrap_or(true),
         })
     }
 }
@@ -925,7 +925,7 @@ pub mod test_helpers {
             experimental_features_enabled: false,
             additional_metric_tags: vec![],
             additional_metric_tags_cardinality_limit: None,
-            agent_stats_computation_enabled: false,
+            agent_stats_computation_enabled: true,
         }
     }
 }

--- a/crates/datadog-trace-agent/src/stats_processor.rs
+++ b/crates/datadog-trace-agent/src/stats_processor.rs
@@ -40,6 +40,16 @@ impl StatsProcessor for ServerlessStatsProcessor {
         tx: Sender<pb::ClientStatsPayload>,
     ) -> http::Result<http_common::HttpResponse> {
         debug!("Received trace stats to process");
+
+        // When the agent computes trace stats itself, tracer computed stats sent to this
+        // endpoint are redundant and are dropped.
+        if config.agent_stats_computation_enabled {
+            return log_and_create_http_response(
+                "Dropping trace stats: agent stats computation is enabled",
+                StatusCode::ACCEPTED,
+            );
+        }
+
         let (parts, body) = req.into_parts();
 
         if let Some(response) = http_utils::verify_request_content_length(

--- a/crates/datadog-trace-agent/src/stats_processor.rs
+++ b/crates/datadog-trace-agent/src/stats_processor.rs
@@ -48,7 +48,11 @@ impl StatsProcessor for ServerlessStatsProcessor {
         // endpoint are redundant and are dropped. The body is still drained so the
         // connection can be kept alive for the next request instead of being closed.
         if config.agent_stats_computation_enabled {
-            let _ = body.collect().await;
+            if let Err(err) = body.collect().await {
+                debug!(
+                    "Error draining /v0.6/stats request body while dropping stats: {err}"
+                );
+            }
             return log_and_create_http_response(
                 "Dropping trace stats: agent stats computation is enabled",
                 StatusCode::ACCEPTED,

--- a/crates/datadog-trace-agent/src/stats_processor.rs
+++ b/crates/datadog-trace-agent/src/stats_processor.rs
@@ -5,6 +5,7 @@ use std::sync::Arc;
 use std::time::UNIX_EPOCH;
 
 use async_trait::async_trait;
+use http_body_util::BodyExt;
 use hyper::{StatusCode, http};
 use libdd_common::http_common;
 use tokio::sync::mpsc::Sender;
@@ -41,16 +42,18 @@ impl StatsProcessor for ServerlessStatsProcessor {
     ) -> http::Result<http_common::HttpResponse> {
         debug!("Received trace stats to process");
 
+        let (parts, body) = req.into_parts();
+
         // When the agent computes trace stats itself, tracer computed stats sent to this
-        // endpoint are redundant and are dropped.
+        // endpoint are redundant and are dropped. The body is still drained so the
+        // connection can be kept alive for the next request instead of being closed.
         if config.agent_stats_computation_enabled {
+            let _ = body.collect().await;
             return log_and_create_http_response(
                 "Dropping trace stats: agent stats computation is enabled",
                 StatusCode::ACCEPTED,
             );
         }
-
-        let (parts, body) = req.into_parts();
 
         if let Some(response) = http_utils::verify_request_content_length(
             &parts.headers,
@@ -93,5 +96,96 @@ impl StatsProcessor for ServerlessStatsProcessor {
                 );
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use hyper::Request;
+    use libdd_trace_obfuscation::obfuscation_config::ObfuscationConfig;
+    use tokio::sync::mpsc;
+
+    use crate::config::{Config, Tags};
+    use crate::peer_tags::peer_tag_keys;
+    use crate::stats_processor::{ServerlessStatsProcessor, StatsProcessor};
+    use libdd_common::{Endpoint, http_common};
+    use libdd_trace_utils::trace_utils;
+
+    fn create_test_config(agent_stats_computation_enabled: bool) -> Config {
+        Config {
+            app_name: Some("dummy_function_name".to_string()),
+            max_request_content_length: 10 * 1024 * 1024,
+            trace_flush_interval_secs: 3,
+            stats_flush_interval_secs: 3,
+            proxy_request_timeout_secs: 30,
+            proxy_request_max_retries: 3,
+            proxy_request_retry_backoff_base_ms: 100,
+            verify_env_timeout_ms: 100,
+            trace_intake: Endpoint {
+                url: hyper::Uri::from_static("https://trace.agent.notdog.com/traces"),
+                api_key: Some("dummy_api_key".into()),
+                ..Default::default()
+            },
+            trace_stats_intake: Endpoint {
+                url: hyper::Uri::from_static("https://trace.agent.notdog.com/stats"),
+                api_key: Some("dummy_api_key".into()),
+                ..Default::default()
+            },
+            dsm_intake: Endpoint {
+                url: hyper::Uri::from_static(
+                    "https://trace.agent.notdog.com/api/v0.1/pipeline_stats",
+                ),
+                api_key: Some("dummy_api_key".into()),
+                ..Default::default()
+            },
+            dd_site: "datadoghq.com".to_string(),
+            dd_apm_receiver_port: 8126,
+            #[cfg(any(all(windows, feature = "windows-pipes"), test))]
+            dd_apm_windows_pipe_name: None,
+            dd_dogstatsd_port: 8125,
+            #[cfg(any(all(windows, feature = "windows-pipes"), test))]
+            dd_dogstatsd_windows_pipe_name: None,
+            env_type: trace_utils::EnvironmentType::CloudFunction,
+            os: "linux".to_string(),
+            obfuscation_config: ObfuscationConfig::new().unwrap(),
+            proxy_url: None,
+            profiling_intake: Endpoint {
+                url: hyper::Uri::from_static("https://proxy.agent.notdog.com/proxy"),
+                api_key: Some("dummy_api_key".into()),
+                ..Default::default()
+            },
+            tags: Tags::from_env_string("env:test,service:my-service"),
+            env: "test-env".to_string(),
+            peer_tags: peer_tag_keys().unwrap(),
+            experimental_features_enabled: false,
+            additional_metric_tags: vec![],
+            additional_metric_tags_cardinality_limit: None,
+            agent_stats_computation_enabled,
+        }
+    }
+
+    // When agent stats computation is enabled, tracer computed stats are dropped rather than
+    // parsed. This body is not valid msgpack, so the test also verifies the request body is never
+    // fed into the stats deserializer on this path.
+    #[tokio::test]
+    async fn test_process_stats_drops_and_drains_when_agent_computes_stats() {
+        let config = std::sync::Arc::new(create_test_config(true));
+        let (tx, mut rx) = mpsc::channel(1);
+
+        let request = Request::builder()
+            .body(http_common::Body::from_bytes(
+                hyper::body::Bytes::from_static(b"not valid msgpack"),
+            ))
+            .unwrap();
+
+        let response = ServerlessStatsProcessor {}
+            .process_stats(config, request, tx)
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), hyper::StatusCode::ACCEPTED);
+        // nothing should have been sent to the stats flusher on this path
+        assert!(rx.try_recv().is_err());
+        drop(rx);
     }
 }

--- a/crates/datadog-trace-agent/src/stats_processor.rs
+++ b/crates/datadog-trace-agent/src/stats_processor.rs
@@ -49,9 +49,7 @@ impl StatsProcessor for ServerlessStatsProcessor {
         // connection can be kept alive for the next request instead of being closed.
         if config.agent_stats_computation_enabled {
             if let Err(err) = body.collect().await {
-                debug!(
-                    "Error draining /v0.6/stats request body while dropping stats: {err}"
-                );
+                debug!("Error draining /v0.6/stats request body while dropping stats: {err}");
             }
             return log_and_create_http_response(
                 "Dropping trace stats: agent stats computation is enabled",

--- a/crates/datadog-trace-agent/src/trace_processor.rs
+++ b/crates/datadog-trace-agent/src/trace_processor.rs
@@ -188,10 +188,10 @@ impl TraceProcessor for ServerlessTraceProcessor {
             }
         }
 
-        // Skip agent side stats computation if disabled or if the tracer has already computed stats
+        // When agent stats computation is enabled, the agent unconditionally computes trace
+        // stats, ignoring the Datadog-Client-Computed-Stats header.
         if let Some(ref concentrator) = self.stats_concentrator
             && config.agent_stats_computation_enabled
-            && !tracer_header_tags.generic.client_computed_stats
         {
             Self::send_to_concentrator(concentrator, &payload);
         }

--- a/crates/datadog-trace-agent/tests/common/helpers.rs
+++ b/crates/datadog-trace-agent/tests/common/helpers.rs
@@ -54,6 +54,22 @@ pub fn create_client_span_with_peer_tag_payload() -> Vec<u8> {
     rmp_serde::to_vec(&vec![vec![span]]).expect("Failed to serialize client peer tag trace")
 }
 
+/// Build a raw, uncompressed, msgpack `ClientStatsPayload` body as sent by a tracer directly
+/// to `/v0.6/stats`. `service` is used to distinguish tracer computed stats from agent computed stats.
+pub fn create_test_client_stats_payload(service: &str) -> Vec<u8> {
+    let payload = pb::ClientStatsPayload {
+        service: service.to_string(),
+        stats: vec![pb::ClientStatsBucket {
+            start: 0,
+            duration: 10_000_000_000,
+            stats: vec![],
+            agent_time_shift: 0,
+        }],
+        ..Default::default()
+    };
+    rmp_serde::to_vec_named(&payload).expect("Failed to serialize client stats payload")
+}
+
 /// Decompress a gzip+msgpack stats payload and deserialize it into a `StatsPayload`.
 /// The stats flusher encodes payloads as `gzip(rmp_serde::to_vec_named(StatsPayload))`.
 pub fn decode_stats_payload(body: &[u8]) -> pb::StatsPayload {

--- a/crates/datadog-trace-agent/tests/integration_test.rs
+++ b/crates/datadog-trace-agent/tests/integration_test.rs
@@ -4,8 +4,9 @@
 mod common;
 
 use common::helpers::{
-    create_client_span_with_peer_tag_payload, create_test_trace_payload,
-    create_trace_with_span_kind_children_payload, decode_stats_payload, send_tcp_request,
+    create_client_span_with_peer_tag_payload, create_test_client_stats_payload,
+    create_test_trace_payload, create_trace_with_span_kind_children_payload, decode_stats_payload,
+    send_tcp_request,
 };
 use common::mock_server::MockServer;
 use common::mocks::{MockEnvVerifier, MockStatsFlusher, MockStatsProcessor, MockTraceFlusher};
@@ -302,8 +303,8 @@ async fn test_mini_agent_tcp_handles_requests() {
 
     // Check client_drop_p0s flag
     assert_eq!(
-        json["client_drop_p0s"], true,
-        "Expected client_drop_p0s to be true"
+        json["client_drop_p0s"], false,
+        "Expected client_drop_p0s to be false"
     );
 
     // Check span_kinds_stats_computed
@@ -418,8 +419,8 @@ async fn test_mini_agent_named_pipe_handles_requests() {
 
     // Check client_drop_p0s flag
     assert_eq!(
-        json["client_drop_p0s"], true,
-        "Expected client_drop_p0s to be true"
+        json["client_drop_p0s"], false,
+        "Expected client_drop_p0s to be false"
     );
 
     // Check span_kinds_stats_computed
@@ -659,12 +660,13 @@ async fn test_concentrator_task_death_shuts_down_mini_agent() {
 #[cfg(test)]
 #[tokio::test]
 #[serial]
-async fn test_mini_agent_tcp_with_real_flushers_and_tracer_computed_stats() {
+async fn test_tracer_and_agent_stats_disabled_produces_no_stats() {
     let mock_server: MockServer = MockServer::start().await;
     tokio::time::sleep(Duration::from_millis(50)).await;
 
     let mut config = create_tcp_test_config(8128); // use different port to avoid race condition with other tests
     configure_mock_endpoints(&mut config, &mock_server.url());
+    config.agent_stats_computation_enabled = false;
     let config = Arc::new(config);
     let test_port = config.dd_apm_receiver_port;
 
@@ -692,7 +694,133 @@ async fn test_mini_agent_tcp_with_real_flushers_and_tracer_computed_stats() {
         "Mini agent server failed to start within timeout"
     );
 
-    // Send trace data
+    // Send trace data with no Datadog-Client-Computed-Stats header to indicate tracer has not computed its own stats, and don't make a request to /v0.6/stats.
+    let trace_payload = create_test_trace_payload(None);
+    let trace_response =
+        send_tcp_request(test_port, "/v0.4/traces", "POST", Some(trace_payload), &[])
+            .await
+            .expect("Failed to send /v0.4/traces request");
+    assert_eq!(trace_response.status(), StatusCode::OK);
+
+    verify_trace_request(&mock_server).await;
+    // Bounded wait to confirm absence of stats request — neither side computed stats.
+    tokio::time::sleep(FLUSH_WAIT_DURATION).await;
+    verify_no_stats_request(&mock_server);
+
+    // Clean up
+    agent_handle.abort();
+}
+
+#[cfg(test)]
+#[tokio::test]
+#[serial]
+async fn test_tracer_disabled_agent_stats_enabled_uses_agent_stats() {
+    let mock_server: MockServer = MockServer::start().await;
+    tokio::time::sleep(Duration::from_millis(50)).await;
+
+    let mut config = create_tcp_test_config(8136); // use different port to avoid race condition with other tests
+    configure_mock_endpoints(&mut config, &mock_server.url());
+    config.agent_stats_computation_enabled = true;
+    let config = Arc::new(config);
+    let test_port = config.dd_apm_receiver_port;
+
+    let (mini_agent, stats_concentrator_service_handle) =
+        create_mini_agent_with_real_flushers(config);
+
+    let agent_handle = tokio::spawn(async move {
+        let (_shutdown_tx, shutdown_rx) = tokio::sync::watch::channel(false);
+        let _ = mini_agent
+            .start_mini_agent(shutdown_rx, Some(stats_concentrator_service_handle))
+            .await;
+    });
+
+    // Wait for server to be ready
+    let mut server_ready = false;
+    for _ in 0..20 {
+        tokio::time::sleep(Duration::from_millis(50)).await;
+        if let Ok(response) = send_tcp_request(test_port, "/info", "GET", None, &[]).await
+            && response.status().is_success()
+        {
+            server_ready = true;
+            break;
+        }
+    }
+    assert!(
+        server_ready,
+        "Mini agent server failed to start within timeout"
+    );
+
+    // Send trace data with no Datadog-Client-Computed-Stats header to indicate tracer has not computed its own stats, and don't make a request to /v0.6/stats.
+    let trace_payload = create_test_trace_payload(None);
+    let trace_response =
+        send_tcp_request(test_port, "/v0.4/traces", "POST", Some(trace_payload), &[])
+            .await
+            .expect("Failed to send /v0.4/traces request");
+    assert_eq!(trace_response.status(), StatusCode::OK);
+
+    verify_trace_request(&mock_server).await;
+    verify_stats_request(&mock_server).await; // Agent should compute stats
+
+    // Clean up
+    agent_handle.abort();
+}
+
+#[tokio::test]
+#[serial]
+async fn test_tracer_and_agent_stats_enabled_uses_agent_stats_no_duplicates() {
+    let mock_server: MockServer = MockServer::start().await;
+    tokio::time::sleep(Duration::from_millis(50)).await;
+
+    let mut config = create_tcp_test_config(8135); // use different port to avoid race condition with other tests
+    configure_mock_endpoints(&mut config, &mock_server.url());
+    config.agent_stats_computation_enabled = true;
+    let config = Arc::new(config);
+    let test_port = config.dd_apm_receiver_port;
+
+    let (mini_agent, stats_concentrator_service_handle) =
+        create_mini_agent_with_real_flushers(config);
+
+    let agent_handle = tokio::spawn(async move {
+        let (_shutdown_tx, shutdown_rx) = tokio::sync::watch::channel(false);
+        let _ = mini_agent
+            .start_mini_agent(shutdown_rx, Some(stats_concentrator_service_handle))
+            .await;
+    });
+
+    // Wait for server to be ready
+    let mut server_ready = false;
+    for _ in 0..20 {
+        tokio::time::sleep(Duration::from_millis(50)).await;
+        if let Ok(response) = send_tcp_request(test_port, "/info", "GET", None, &[]).await
+            && response.status().is_success()
+        {
+            server_ready = true;
+            break;
+        }
+    }
+    assert!(
+        server_ready,
+        "Mini agent server failed to start within timeout"
+    );
+
+    // Send trace data with Datadog-Client-Computed-Stats header to indicate tracer has computed its own stats, and make a request to /v0.6/stats.
+    // Tag with a marker service so we can tell them apart from anything the agent computes itself.
+    let stats_response = send_tcp_request(
+        test_port,
+        "/v0.6/stats",
+        "POST",
+        Some(create_test_client_stats_payload("tracer-marker-stats")),
+        &[],
+    )
+    .await
+    .expect("Failed to send /v0.6/stats request");
+    assert_eq!(
+        stats_response.status(),
+        StatusCode::ACCEPTED,
+        "Expected /v0.6/stats to accept and drop the request"
+    );
+
+    // The agent should ignore Datadog-Client-Computed-Stats and compute stats.
     let trace_payload = create_test_trace_payload(None);
     let trace_response = send_tcp_request(
         test_port,
@@ -706,10 +834,94 @@ async fn test_mini_agent_tcp_with_real_flushers_and_tracer_computed_stats() {
     assert_eq!(trace_response.status(), StatusCode::OK);
 
     verify_trace_request(&mock_server).await;
-    // Bounded wait to confirm absence of stats request — stats wouldn't
-    // be generated when Datadog-Client-Computed-Stats is set on the trace.
-    tokio::time::sleep(FLUSH_WAIT_DURATION).await;
-    verify_no_stats_request(&mock_server);
+    verify_stats_request(&mock_server).await;
+
+    // The tracer computed stats should never reach the backend. Only the agent computed stats should reach the backend.
+    let stats_reqs = mock_server.get_requests_for_path("/api/v0.2/stats");
+    let has_marker = stats_reqs
+        .iter()
+        .map(|req| decode_stats_payload(&req.body))
+        .any(|payload| {
+            payload
+                .stats
+                .iter()
+                .any(|csp| csp.service == "tracer-marker-stats")
+        });
+    assert!(
+        !has_marker,
+        "Expected tracer computed stats to be dropped, not forwarded to the backend"
+    );
+
+    // Clean up
+    agent_handle.abort();
+}
+
+#[tokio::test]
+#[serial]
+async fn test_tracer_stats_enabled_agent_stats_disabled_forwards_tracer_stats() {
+    let mock_server: MockServer = MockServer::start().await;
+    tokio::time::sleep(Duration::from_millis(50)).await;
+
+    let mut config = create_tcp_test_config(8134); // use different port to avoid race condition with other tests
+    configure_mock_endpoints(&mut config, &mock_server.url());
+    config.agent_stats_computation_enabled = false;
+    let config = Arc::new(config);
+    let test_port = config.dd_apm_receiver_port;
+
+    let (mini_agent, _stats_concentrator_service_handle) =
+        create_mini_agent_with_real_flushers(config);
+
+    let agent_handle = tokio::spawn(async move {
+        let (_shutdown_tx, shutdown_rx) = tokio::sync::watch::channel(false);
+        let _ = mini_agent.start_mini_agent(shutdown_rx, None).await;
+    });
+
+    // Wait for server to be ready
+    let mut server_ready = false;
+    for _ in 0..20 {
+        tokio::time::sleep(Duration::from_millis(50)).await;
+        if let Ok(response) = send_tcp_request(test_port, "/info", "GET", None, &[]).await
+            && response.status().is_success()
+        {
+            server_ready = true;
+            break;
+        }
+    }
+    assert!(
+        server_ready,
+        "Mini agent server failed to start within timeout"
+    );
+
+    // Send trace data with Datadog-Client-Computed-Stats header to indicate tracer has computed its own stats, and make a request to /v0.6/stats.
+    let stats_response = send_tcp_request(
+        test_port,
+        "/v0.6/stats",
+        "POST",
+        Some(create_test_client_stats_payload("tracer-marker-stats")),
+        &[],
+    )
+    .await
+    .expect("Failed to send /v0.6/stats request");
+    assert_eq!(stats_response.status(), StatusCode::ACCEPTED);
+
+    verify_stats_request(&mock_server).await;
+    let stats_reqs = mock_server.get_requests_for_path("/api/v0.2/stats");
+    let has_marker = stats_reqs
+        .iter()
+        .map(|req| decode_stats_payload(&req.body))
+        .any(|payload| {
+            payload
+                .stats
+                .iter()
+                .any(|csp| csp.service == "tracer-marker-stats")
+        });
+    assert!(
+        has_marker,
+        "Expected tracer computed stats to be forwarded to the backend"
+    );
+
+    // Clean up
+    agent_handle.abort();
 
     // Clean up
     agent_handle.abort();

--- a/crates/datadog-trace-agent/tests/integration_test.rs
+++ b/crates/datadog-trace-agent/tests/integration_test.rs
@@ -922,9 +922,6 @@ async fn test_tracer_stats_enabled_agent_stats_disabled_forwards_tracer_stats() 
 
     // Clean up
     agent_handle.abort();
-
-    // Clean up
-    agent_handle.abort();
 }
 
 /// Verify that `span_kinds_stats_computed` controls which non-top-level, non-measured child spans


### PR DESCRIPTION
### What does this PR do?

- Enable agent stats computation by default
- Set `client_drop_p0s` to `false` when agent stats computation is enabled
- Ignore `Datadog-Client-Computed-Stats` when agent stats computation is enabled
- Drop stats sent from tracer to `/v0.6/stats` when agent stats computation is enabled

### Motivation

https://docs.google.com/document/d/1RudMlGPZgvPDOaU6VTGW5Z5NuZzZswcPHLzuuOIX0YQ/edit?usp=sharing

https://datadoghq.atlassian.net/browse/SVLS-9033

### Additional Notes

See attached card for additional test cases.

### Describe how to test/QA your changes

Made 10,000 requests with `plow "$url" -c 50 -n 10000` and validated that the correct number of spans and trace stats are received by Datadog.

100% sampling, agent stats enabled, tracer stats disabled ✅ 

<img width="1402" height="506" alt="Screenshot 2026-07-22 at 4 48 02 PM" src="https://github.com/user-attachments/assets/b1ba0da5-ec57-4d60-ab00-1bd90f1f7581" />

100% sampling, agent stats disabled, tracer stats enabled ⚠️ - minor discrepancies in tracer computed stats for Java and .NET to be investigated in a follow up ticket

<img width="1404" height="504" alt="Screenshot 2026-07-22 at 4 49 53 PM" src="https://github.com/user-attachments/assets/8ca2baa4-00f4-4479-816b-b3ce3c1e061b" />

50% sampling, agent stats enabled, tracer stats disabled ✅ 

<img width="1406" height="502" alt="Screenshot 2026-07-22 at 5 00 41 PM" src="https://github.com/user-attachments/assets/b07f8a6b-8ba3-4281-9b86-a5ffd3f833e1" />

50% sampling, agent stats disabled, tracer stats enabled ⚠️ - minor discrepancies in tracer computed stats for .NET to be investigated in a follow up ticket
<img width="1403" height="501" alt="Screenshot 2026-07-22 at 5 02 46 PM" src="https://github.com/user-attachments/assets/b21e90a9-a84f-4719-9ada-567f542ac68f" />


