### PR TITLE
chore: fix clippy warnings

### DIFF
--- a/crates/dogstatsd/src/datadog/shipping.rs
+++ b/crates/dogstatsd/src/datadog/shipping.rs
@@ -43,7 +43,7 @@ impl DdApi {
 
     /// Ship a serialized series to the API, blocking
     pub async fn ship_series(&self, series: &Series) -> Result<Response, ShippingError> {
-        let url = format!("{}/api/v2/series", &self.metrics_intake_url_prefix);
+        let url = format!("{}/api/v2/series", self.metrics_intake_url_prefix);
         let safe_body = serde_json::to_vec(&series)
             .map_err(|e| ShippingError::Payload(format!("Failed to serialize series: {e}")))?;
         trace!("Sending body: {:?}", &series);
@@ -54,7 +54,7 @@ impl DdApi {
         &self,
         sketches: &SketchPayload,
     ) -> Result<Response, ShippingError> {
-        let url = format!("{}/api/beta/sketches", &self.metrics_intake_url_prefix);
+        let url = format!("{}/api/beta/sketches", self.metrics_intake_url_prefix);
         let safe_body = sketches
             .write_to_bytes()
             .map_err(|e| ShippingError::Payload(format!("Failed to serialize series: {e}")))?;

--- a/crates/dogstatsd/src/datadog/shipping.rs
+++ b/crates/dogstatsd/src/datadog/shipping.rs
@@ -57,7 +57,7 @@ impl DdApi {
         let url = format!("{}/api/beta/sketches", self.metrics_intake_url_prefix);
         let safe_body = sketches
             .write_to_bytes()
-            .map_err(|e| ShippingError::Payload(format!("Failed to serialize series: {e}")))?;
+            .map_err(|e| ShippingError::Payload(format!("Failed to serialize sketches: {e}")))?;
         trace!("Sending distributions: {:?}", &sketches);
         self.ship_data(url, safe_body, "application/x-protobuf")
             .await

--- a/crates/dogstatsd/src/util.rs
+++ b/crates/dogstatsd/src/util.rs
@@ -40,7 +40,8 @@ pub fn parse_metric_namespace(namespace: &str) -> Option<String> {
     let mut chars = trimmed.chars();
 
     // Check first character is a letter
-    if let Some(first_char) = chars.next() {
+    {
+        let first_char = chars.next()?;
         if !first_char.is_ascii_alphabetic() {
             tracing::error!(
                 "DD_STATSD_METRIC_NAMESPACE must start with a letter, got: '{}'. Ignoring namespace.",
@@ -48,8 +49,6 @@ pub fn parse_metric_namespace(namespace: &str) -> Option<String> {
             );
             return None;
         }
-    } else {
-        return None;
     }
 
     // Check remaining characters are valid (alphanumeric, underscore, or period)


### PR DESCRIPTION
### What does this PR do?

Fixes clippy warnings.

### Motivation

https://github.com/DataDog/serverless-components/actions/runs/29588791501/job/87912458431?pr=146
```
error: redundant reference in `format!` argument
  --> crates/dogstatsd/src/datadog/shipping.rs:46:47
   |
46 |         let url = format!("{}/api/v2/series", &self.metrics_intake_url_prefix);
   |                                               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: remove the redundant `&`: `self.metrics_intake_url_prefix`
   |
   = help: for further information visit https://rust-lang.github.io/rust-clippy/rust-1.97.0/index.html#useless_borrows_in_formatting
   = note: `-D clippy::useless-borrows-in-formatting` implied by `-D warnings`
   = help: to override `-D warnings` add `#[allow(clippy::useless_borrows_in_formatting)]`

error: redundant reference in `format!` argument
  --> crates/dogstatsd/src/datadog/shipping.rs:57:51
   |
57 |         let url = format!("{}/api/beta/sketches", &self.metrics_intake_url_prefix);
   |                                                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: remove the redundant `&`: `self.metrics_intake_url_prefix`
   |
   = help: for further information visit https://rust-lang.github.io/rust-clippy/rust-1.97.0/index.html#useless_borrows_in_formatting

error: this block may be rewritten with the `?` operator
  --> crates/dogstatsd/src/util.rs:43:5
   |
43 | /     if let Some(first_char) = chars.next() {
44 | |         if !first_char.is_ascii_alphabetic() {
45 | |             tracing::error!(
46 | |                 "DD_STATSD_METRIC_NAMESPACE must start with a letter, got: '{}'. Ignoring namespace.",
...  |
52 | |         return None;
53 | |     }
   | |_____^
   |
   = help: for further information visit https://rust-lang.github.io/rust-clippy/rust-1.97.0/index.html#question_mark
   = note: `-D clippy::question-mark` implied by `-D warnings`
   = help: to override `-D warnings` add `#[allow(clippy::question_mark)]`
help: replace it with
   |
43 ~     {
44 +         let first_char = chars.next()?;
45 +         if !first_char.is_ascii_alphabetic() {
46 +             tracing::error!(
47 +                 "DD_STATSD_METRIC_NAMESPACE must start with a letter, got: '{}'. Ignoring namespace.",
48 +                 trimmed
49 +             );
50 +             return None;
51 +         }
52 +     }
   |
```

### Additional Notes

<!-- Any other relevant context that would be helpful. -->

### Describe how to test/QA your changes

<!-- How was the change validated? Are there automated tests to prevent regressions? -->
